### PR TITLE
`ZeroPadding2D` layer implementation

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2D.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.twodim
+
+import org.jetbrains.kotlinx.dl.api.core.KGraph
+import org.jetbrains.kotlinx.dl.api.core.layer.Layer
+import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_FIRST
+import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_LAST
+import org.tensorflow.Operand
+import org.tensorflow.Shape
+import org.tensorflow.op.Ops
+
+class ZeroPadding2D(
+    val padding: IntArray,
+    private val dataFormat: String? = CHANNELS_LAST,
+    name: String = ""
+) : Layer(name) {
+
+    private lateinit var inputShape: Shape
+
+    override fun defineVariables(tf: Ops, kGraph: KGraph, inputShape: Shape) {
+        this.inputShape = inputShape
+    }
+
+    override fun computeOutputShape(inputShape: Shape): Shape {
+        assert(inputShape.numDimensions() == 4) { "input tensor must have 4 dimensions" }
+
+        val normalizedPadding = normalizePaddingArray()
+        return if (dataFormat == CHANNELS_FIRST) {
+            Shape.make(
+                inputShape.size(0),
+                inputShape.size(1),
+                inputShape.size(2) + normalizedPadding[0] + normalizedPadding[1],
+                inputShape.size(3) + normalizedPadding[2] + normalizedPadding[3]
+            )
+        } else {
+            Shape.make(
+                inputShape.size(0),
+                inputShape.size(1) + normalizedPadding[0] + normalizedPadding[1],
+                inputShape.size(2) + normalizedPadding[2] + normalizedPadding[3],
+                inputShape.size(3)
+            )
+        }
+    }
+
+
+    override fun transformInput(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val paddingOperand = tf.constant(paddingArrayToTfFormat())
+        val constantValue = tf.constant(0f)
+        return tf.pad(input, paddingOperand, constantValue)
+    }
+
+    override fun getWeights(): List<Array<*>> {
+        return emptyList()
+    }
+
+    override fun hasActivation(): Boolean {
+        return false
+    }
+
+    override fun getParams(): Int {
+        return 0
+    }
+
+    override fun toString(): String {
+        return "ZeroPadding2D(padding=$padding)"
+    }
+
+    private fun normalizePaddingArray(): IntArray {
+        return when (padding.size) {
+            4 -> padding
+            2 -> intArrayOf(padding[0], padding[0], padding[1], padding[1])
+            1 -> intArrayOf(padding[0], padding[0], padding[0], padding[0])
+            else -> throw IllegalArgumentException("Invalid padding argument at layer $name")
+        }
+    }
+
+    private fun paddingArrayToTfFormat(): Array<IntArray> {
+        val paddingFirstDim: IntArray
+        val paddingSecondDim: IntArray
+
+        when (padding.size) {
+            4 -> {
+                paddingFirstDim = intArrayOf(padding[0], padding[1])
+                paddingSecondDim = intArrayOf(padding[2], padding[3])
+            }
+            2 -> {
+                paddingFirstDim = intArrayOf(padding[0], padding[0])
+                paddingSecondDim = intArrayOf(padding[1], padding[1])
+            }
+            1 -> {
+                paddingFirstDim = intArrayOf(padding[0], padding[0])
+                paddingSecondDim = intArrayOf(padding[0], padding[0])
+            }
+            else -> throw IllegalArgumentException("Invalid padding argument at layer $name")
+        }
+        return paddingArraysToInputShape(paddingFirstDim, paddingSecondDim)
+    }
+
+    private fun paddingArraysToInputShape(paddingFirstDim: IntArray, paddingSecondDim: IntArray): Array<IntArray> {
+        return when (inputShape.numDimensions()) {
+            4 -> {
+                if (dataFormat == CHANNELS_FIRST) {
+                    arrayOf(intArrayOf(0, 0), intArrayOf(0, 0), paddingFirstDim, paddingSecondDim)
+                } else {
+                    arrayOf(intArrayOf(0, 0), paddingFirstDim, paddingSecondDim, intArrayOf(0, 0))
+                }
+            }
+            3 -> {
+                if (dataFormat == CHANNELS_FIRST) {
+                    arrayOf(intArrayOf(0, 0), paddingFirstDim, paddingSecondDim)
+                } else {
+                    arrayOf(paddingFirstDim, paddingSecondDim, intArrayOf(0, 0))
+                }
+            }
+            2 -> {
+                arrayOf(paddingFirstDim, paddingSecondDim)
+            }
+            else -> throw IllegalArgumentException("Invalid input shape $inputShape")
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstans.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstans.kt
@@ -11,6 +11,7 @@ internal const val LAYER_DENSE: String = "Dense"
 internal const val LAYER_MAX_POOLING_2D: String = "MaxPooling2D"
 internal const val LAYER_AVG_POOLING_2D: String = "AvgPooling2D"
 internal const val LAYER_FLATTEN: String = "Flatten"
+internal const val LAYER_ZERO_PADDING_2D = "ZeroPadding2D"
 
 // Keras data types
 internal const val DATATYPE_FLOAT32: String = "float32"
@@ -48,4 +49,5 @@ internal const val ACTIVATION_EXP: String = "exponential"
 
 // Layer settings
 internal const val CHANNELS_LAST: String = "channels_last"
+internal const val CHANNELS_FIRST = "channels_first"
 internal const val PADDING_SAME: String = "same"

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -59,6 +59,7 @@ internal fun loadModelLayers(jsonConfigFile: File): Pair<Input, MutableList<Laye
         e.printStackTrace()
         try {
             Klaxon()
+                .converter(PaddingConverter())
                 .parse<KerasSequentialModel>(jsonConfigFile)
         } catch (e: Exception) {
             e.printStackTrace()

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelParser.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelParser.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import com.beust.klaxon.Converter
+import com.beust.klaxon.JsonArray
+import com.beust.klaxon.JsonValue
+import org.jetbrains.kotlinx.dl.api.inference.keras.config.KerasPadding
+
+internal class PaddingConverter : Converter {
+    override fun canConvert(cls: Class<*>): Boolean {
+        return cls == KerasPadding::class.java
+    }
+
+    override fun toJson(value: Any): String {
+        return when (value) {
+            is KerasPadding.Full -> "\"full\""
+            is KerasPadding.Same -> "\"same\""
+            is KerasPadding.Valid -> "\"valid\""
+            is KerasPadding.ZeroPadding2D -> zeroPaddingToJsonString(value)
+            else -> {
+                println("[KerasPaddingConverter]: Converting unknown padding $value to JSON")
+                return "$value"
+            }
+        }
+    }
+
+    private fun zeroPaddingToJsonString(zeroPadding2D: KerasPadding.ZeroPadding2D): String {
+        with(zeroPadding2D) {
+            return when (padding.size) {
+                1 -> """${padding[0]}"""
+                2 -> """[${padding[0]}, ${padding[1]}]"""
+                4 -> """[[${padding[0]}, ${padding[1]}], [${padding[2]}, ${padding[3]}]]"""
+                else -> throw IllegalArgumentException("[KerasPaddingConverter]: expected padding array with size 1, 2 or 4, got array $padding")
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromJson(jv: JsonValue): KerasPadding? {
+        // See https://github.com/tensorflow/tensorflow/blob/582c8d236cb079023657287c318ff26adb239002/tensorflow/python/keras/layers/pooling.py#L470
+        // and https://github.com/tensorflow/tensorflow/blob/582c8d236cb079023657287c318ff26adb239002/tensorflow/python/keras/layers/convolutional.py#L2795
+        // for detailed explaination of supported formats.
+        // Could be string for `same`, `valid` or `causal`,
+        // or Int, or tuple of 2 ints, or tuple of 2 tuples of 2 ints - for ZeroPadding layer.
+
+        val stringValue = jv.string
+        if (stringValue != null) {
+            return when (stringValue) {
+                "same" -> KerasPadding.Same
+                "valid" -> KerasPadding.Valid
+                "full" -> KerasPadding.Full
+                else -> throw UnsupportedOperationException("[KerasPaddingConverter]: Invalid padding $jv: the $stringValue padding is not supported!")
+            }
+        }
+
+        val intValue = jv.int
+        if (intValue != null) {
+            return KerasPadding.ZeroPadding2D(intArrayOf(intValue))
+        }
+
+        val array = jv.array
+        if (array != null) {
+            assert(array.size == 2) {
+                "[KerasPaddingConverter]: invalid padding shape in $jv, received ${array.size}, expected 2"
+            }
+            when (array[0]) {
+                is Int -> {
+                    assert(array[1] is Int) { "[KerasPaddingConverter]: invalid padding $jv, expected Integer at ${array[1]}" }
+                    return KerasPadding.ZeroPadding2D(intArrayOf(array[0] as Int, array[1] as Int))
+                }
+                is JsonArray<*> -> {
+                    assert(array[1] is JsonArray<*>) { "[KerasPaddingConverter]: invalid padding $jv, expected JsonArray at ${array[1]}" }
+                    val firstArray = array[0] as JsonArray<Int>
+                    val secondArray = array[1] as JsonArray<Int>
+                    return KerasPadding.ZeroPadding2D(intArrayOf(
+                        firstArray[0],
+                        firstArray[1],
+                        secondArray[0],
+                        secondArray[1]
+                    ))
+                }
+            }
+        }
+
+        throw UnsupportedOperationException("[KerasPaddingConverter]: Unsupported padding $jv")
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -43,7 +43,9 @@ public fun Sequential.saveModelConfiguration(jsonConfigFile: File, isKerasFullyC
     val config = SequentialConfig(name = "", layers = kerasLayers)
     val sequentialConfig = KerasSequentialModel(config = config)
 
-    val jsonString2 = Klaxon().toJsonString(sequentialConfig)
+    val jsonString2 = Klaxon()
+        .converter(PaddingConverter())
+        .toJsonString(sequentialConfig)
 
     jsonConfigFile.writeText(jsonString2, Charsets.UTF_8)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.twodim.AvgPool2D
 import org.jetbrains.kotlinx.dl.api.core.layer.twodim.Conv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.twodim.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.twodim.MaxPool2D
+import org.jetbrains.kotlinx.dl.api.core.layer.twodim.ZeroPadding2D
 import org.jetbrains.kotlinx.dl.api.inference.keras.config.*
 import java.io.File
 
@@ -54,6 +55,7 @@ private fun convertToKerasLayer(layer: Layer, isKerasFullyCompatible: Boolean): 
         MaxPool2D::class -> createKerasMaxPooling2D(layer as MaxPool2D)
         AvgPool2D::class -> createKerasAvgPooling2D(layer as AvgPool2D)
         Dense::class -> createKerasDense(layer as Dense, isKerasFullyCompatible)
+        ZeroPadding2D::class -> createKerasZeroPadding2D(layer as ZeroPadding2D)
         else -> throw IllegalStateException("${layer.name} is not supported yet!")
     }
 }
@@ -130,11 +132,11 @@ private fun convertMode(mode: Mode): String {
     }
 }
 
-private fun convertPadding(padding: ConvPadding): String {
+private fun convertPadding(padding: ConvPadding): KerasPadding {
     return when (padding) {
-        ConvPadding.SAME -> "same"
-        ConvPadding.VALID -> "valid"
-        ConvPadding.FULL -> "full"
+        ConvPadding.SAME -> KerasPadding.Same
+        ConvPadding.VALID -> KerasPadding.Valid
+        ConvPadding.FULL -> KerasPadding.Full
     }
 }
 
@@ -209,4 +211,14 @@ private fun createKerasConv2D(layer: Conv2D, isKerasFullyCompatible: Boolean): K
         use_bias = true
     )
     return KerasLayer(class_name = LAYER_CONV2D, config = configX)
+}
+
+private fun createKerasZeroPadding2D(layer: ZeroPadding2D): KerasLayer {
+    val configX = LayerConfig(
+        data_format = CHANNELS_LAST,
+        dtype = DATATYPE_FLOAT32,
+        name = layer.name,
+        padding = KerasPadding.ZeroPadding2D(layer.padding)
+    )
+    return KerasLayer(class_name = LAYER_ZERO_PADDING_2D, config = configX)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/KerasPadding.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/KerasPadding.kt
@@ -5,6 +5,11 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.keras.config
 
+/**
+ * This class enumerates all possible `padding` types, which could be faced in config-files.
+ * Those are strings, like "same", "valid", "full" (for example, from `Conv2D` layers),
+ * and numeric values/tuples from `ZeroPadding2D`
+ */
 internal sealed class KerasPadding {
     object Same : KerasPadding()
 
@@ -13,18 +18,20 @@ internal sealed class KerasPadding {
     object Full : KerasPadding()
 
     class ZeroPadding2D : KerasPadding {
-        val padding: IntArray = IntArray(4) { 0 }
+        val padding: IntArray
 
         constructor(padding: Int) {
-            this.padding[0] = padding
+            this.padding = IntArray(1) { padding }
         }
 
         constructor(padding: IntArray) {
+            this.padding = IntArray(2)
             this.padding[0] = padding[0]
             this.padding[1] = padding[1]
         }
 
         constructor(padding: Array<IntArray>) {
+            this.padding = IntArray(4)
             this.padding[0] = padding[0][0]
             this.padding[1] = padding[0][1]
             this.padding[2] = padding[1][0]

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/KerasPadding.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/KerasPadding.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras.config
+
+internal sealed class KerasPadding {
+    object Same : KerasPadding()
+
+    object Valid : KerasPadding()
+
+    object Full : KerasPadding()
+
+    class ZeroPadding2D : KerasPadding {
+        val padding: IntArray = IntArray(4) { 0 }
+
+        constructor(padding: Int) {
+            this.padding[0] = padding
+        }
+
+        constructor(padding: IntArray) {
+            this.padding[0] = padding[0]
+            this.padding[1] = padding[1]
+        }
+
+        constructor(padding: Array<IntArray>) {
+            this.padding[0] = padding[0][0]
+            this.padding[1] = padding[0][1]
+            this.padding[2] = padding[1][0]
+            this.padding[3] = padding[1][1]
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
@@ -21,7 +21,7 @@ internal data class LayerConfig(
     val kernel_regularizer: KerasRegularizer? = null,
     val kernel_size: List<Int>? = null,
     val name: String? = null,
-    val padding: String? = null,
+    val padding: KerasPadding? = null,
     val pool_size: List<Int>? = null,
     val strides: List<Int>? = null,
     val trainable: Boolean? = true,

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2DTest.kt
@@ -25,14 +25,13 @@ internal class ZeroPadding2DTest {
     @Test
     fun oneArgumentChannelsLast() {
         val padding = 1
-        val paddingArray = intArrayOf(padding)
         val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
         val inputShape = Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
         val expectedOutputSize = IMAGE_SIZE + 2 * padding
 
         EagerSession.create().use {
             val tf = Ops.create(it)
-            val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
+            val paddingLayer = ZeroPadding2D(padding, dataFormat = CHANNELS_LAST)
             val inputDimensions = tf.constant(inputDimensionsArray)
             val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
             paddingLayer.defineVariables(tf, KGraph(Graph().toGraphDef()), inputShape)
@@ -77,7 +76,7 @@ internal class ZeroPadding2DTest {
     fun twoArgumentsChannelsLast() {
         val paddingHeight = 1
         val paddingWidth = 2
-        val paddingArray = intArrayOf(paddingHeight, paddingWidth)
+        val paddingArray = paddingHeight to paddingWidth
         val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
         val inputShape = Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
         val expectedOutputHeight = IMAGE_SIZE + paddingHeight * 2

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/twodim/ZeroPadding2DTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.twodim
+
+import org.jetbrains.kotlinx.dl.api.core.KGraph
+import org.jetbrains.kotlinx.dl.api.core.initializer.Ones
+import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
+import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_LAST
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.tensorflow.EagerSession
+import org.tensorflow.Graph
+import org.tensorflow.Shape
+import org.tensorflow.op.Ops
+
+private const val BATCH_SIZE = 1
+private const val NUM_CHANNELS = 1
+private const val IMAGE_SIZE = 3
+
+internal class ZeroPadding2DTest {
+
+    @Test
+    fun oneArgumentChannelsLast() {
+        val padding = 1
+        val paddingArray = intArrayOf(padding)
+        val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
+        val inputShape = Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
+        val expectedOutputSize = IMAGE_SIZE + 2 * padding
+
+        EagerSession.create().use {
+            val tf = Ops.create(it)
+            val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
+            val inputDimensions = tf.constant(inputDimensionsArray)
+            val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
+            paddingLayer.defineVariables(tf, KGraph(Graph().toGraphDef()), inputShape)
+            val output = paddingLayer.transformInput(tf, input).asOutput().tensor()
+
+            val expectedShape = Shape.make(
+                BATCH_SIZE.toLong(),
+                expectedOutputSize.toLong(),
+                expectedOutputSize.toLong(),
+                NUM_CHANNELS.toLong()
+            )
+            val actualShape = shapeFromDims(*output.shape())
+            assertEquals(expectedShape, actualShape)
+
+            val actualArray = Array(BATCH_SIZE) {
+                Array(expectedOutputSize) {
+                    Array(expectedOutputSize) {
+                        FloatArray(NUM_CHANNELS) { 0f }
+                    }
+                }
+            }
+            output.copyTo(actualArray)
+
+            for (batch in 0 until BATCH_SIZE) {
+                for (i in 0 until expectedOutputSize) {
+                    for (j in 0 until expectedOutputSize) {
+                        for (channel in 0 until NUM_CHANNELS) {
+                            if ((i < padding || i >= IMAGE_SIZE + padding) ||
+                                (j < padding || j >= IMAGE_SIZE + padding)) {
+                                assertEquals(0f, actualArray[batch][i][j][channel])
+                            } else {
+                                assertEquals(1f, actualArray[batch][i][j][channel])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun twoArgumentsChannelsLast() {
+        val paddingHeight = 1
+        val paddingWidth = 2
+        val paddingArray = intArrayOf(paddingHeight, paddingWidth)
+        val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
+        val inputShape = Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
+        val expectedOutputHeight = IMAGE_SIZE + paddingHeight * 2
+        val expectedOutputWidth = IMAGE_SIZE + paddingWidth * 2
+
+        EagerSession.create().use {
+            val tf = Ops.create(it)
+            val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
+            val inputDimensions = tf.constant(inputDimensionsArray)
+            val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
+            paddingLayer.defineVariables(tf, KGraph(Graph().toGraphDef()), inputShape)
+            val output = paddingLayer.transformInput(tf, input).asOutput().tensor()
+
+            val expectedShape = Shape.make(
+                BATCH_SIZE.toLong(),
+                expectedOutputHeight.toLong(),
+                expectedOutputWidth.toLong(),
+                NUM_CHANNELS.toLong()
+            )
+            val actualShape = shapeFromDims(*output.shape())
+            assertEquals(expectedShape, actualShape)
+
+            val actualArray = Array(BATCH_SIZE) {
+                Array(expectedOutputHeight) {
+                    Array(expectedOutputWidth) {
+                        FloatArray(NUM_CHANNELS) { 0f }
+                    }
+                }
+            }
+            output.copyTo(actualArray)
+
+            for (batch in 0 until BATCH_SIZE) {
+                for (i in 0 until expectedOutputHeight) {
+                    for (j in 0 until expectedOutputWidth) {
+                        for (channel in 0 until NUM_CHANNELS) {
+                            if ((i < paddingHeight || i >= IMAGE_SIZE + paddingHeight) ||
+                                (j < paddingWidth || j >= IMAGE_SIZE + paddingWidth)) {
+                                assertEquals(0f, actualArray[batch][i][j][channel])
+                            } else {
+                                assertEquals(1f, actualArray[batch][i][j][channel])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun fourArgumentsChannelsLast() {
+        val paddingTop = 1
+        val paddingBottom = 3
+        val paddingLeft = 2
+        val paddingRight = 4
+        val paddingArray = intArrayOf(paddingTop, paddingBottom, paddingLeft, paddingRight)
+        val inputDimensionsArray = intArrayOf(BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, NUM_CHANNELS)
+        val inputShape = Shape.make(BATCH_SIZE.toLong(), IMAGE_SIZE.toLong(), IMAGE_SIZE.toLong(), NUM_CHANNELS.toLong())
+        val expectedOutputHeight = IMAGE_SIZE + paddingTop + paddingBottom
+        val expectedOutputWidth = IMAGE_SIZE + paddingLeft + paddingRight
+
+        EagerSession.create().use {
+            val tf = Ops.create(it)
+            val paddingLayer = ZeroPadding2D(paddingArray, dataFormat = CHANNELS_LAST)
+            val inputDimensions = tf.constant(inputDimensionsArray)
+            val input = Ones().initialize(1, 1, tf, inputDimensions, "test_input")
+            paddingLayer.defineVariables(tf, KGraph(Graph().toGraphDef()), inputShape)
+            val output = paddingLayer.transformInput(tf, input).asOutput().tensor()
+
+            val expectedShape = Shape.make(
+                BATCH_SIZE.toLong(),
+                expectedOutputHeight.toLong(),
+                expectedOutputWidth.toLong(),
+                NUM_CHANNELS.toLong()
+            )
+            val actualShape = shapeFromDims(*output.shape())
+            assertEquals(expectedShape, actualShape)
+
+            val actualArray = Array(BATCH_SIZE) {
+                Array(expectedOutputHeight) {
+                    Array(expectedOutputWidth) {
+                        FloatArray(NUM_CHANNELS) { 0f }
+                    }
+                }
+            }
+            output.copyTo(actualArray)
+
+            for (batch in 0 until BATCH_SIZE) {
+                for (i in 0 until expectedOutputHeight) {
+                    for (j in 0 until expectedOutputWidth) {
+                        for (channel in 0 until NUM_CHANNELS) {
+                            if ((i < paddingTop || i >= IMAGE_SIZE + paddingTop) ||
+                                (j < paddingLeft || j >= IMAGE_SIZE + paddingLeft)) {
+                                assertEquals(0f, actualArray[batch][i][j][channel])
+                            } else {
+                                assertEquals(1f, actualArray[batch][i][j][channel])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PaddingConverterTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PaddingConverterTest.kt
@@ -81,7 +81,7 @@ internal class PaddingConverterTest {
         var serializedConfig: String
         var jsonObject: JsonObject
 
-        var layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(intArrayOf(1)))
+        var layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(1))
         serializedConfig = klaxon.toJsonString(layerConfig)
         jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
         assertEquals(1, jsonObject["padding"])
@@ -91,7 +91,14 @@ internal class PaddingConverterTest {
         jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
         assertArrayEquals(intArrayOf(1, 2), jsonObject.array<Int>("padding")!!.toIntArray())
 
-        layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(intArrayOf(1, 2, 3, 4)))
+        layerConfig = LayerConfig(
+            padding = KerasPadding.ZeroPadding2D(
+                arrayOf(
+                    intArrayOf(1, 2),
+                    intArrayOf(3, 4)
+                )
+            )
+        )
         serializedConfig = klaxon.toJsonString(layerConfig)
         jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
         val parsedArray = jsonObject.array<JsonArray<Int>>("padding")!!

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PaddingConverterTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/PaddingConverterTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import com.beust.klaxon.JsonArray
+import com.beust.klaxon.JsonObject
+import com.beust.klaxon.Klaxon
+import com.beust.klaxon.Parser
+import org.jetbrains.kotlinx.dl.api.inference.keras.config.KerasPadding
+import org.jetbrains.kotlinx.dl.api.inference.keras.config.LayerConfig
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class PaddingConverterTest {
+    private val klaxon = Klaxon()
+        .converter(PaddingConverter())
+    private val parser = Parser.default()
+
+    @Test
+    fun parseStringValues() {
+        val paddingValidString = """{"padding": "valid"}"""
+        var layerConfig: LayerConfig?
+        layerConfig = klaxon.parse<LayerConfig>(paddingValidString)
+        assertTrue { layerConfig!!.padding is KerasPadding.Valid }
+
+        val paddingSameString = """{"padding": "same"}"""
+        layerConfig = klaxon.parse<LayerConfig>(paddingSameString)
+        assert(layerConfig!!.padding is KerasPadding.Same)
+
+        val paddingFullString = """{"padding": "full"}"""
+        layerConfig = klaxon.parse<LayerConfig>(paddingFullString)
+        assert(layerConfig!!.padding is KerasPadding.Full)
+    }
+
+    @Test
+    fun parseZeroPaddingValues() {
+        val oneValueString = """{"padding": 1}"""
+        (klaxon.parse<LayerConfig>(oneValueString)!!.padding as KerasPadding.ZeroPadding2D).apply {
+            assertArrayEquals(intArrayOf(1), padding)
+        }
+
+        val twoValuesString = """{"padding": [1, 2]}"""
+        (klaxon.parse<LayerConfig>(twoValuesString)!!.padding as KerasPadding.ZeroPadding2D).apply {
+            assertArrayEquals(intArrayOf(1, 2), padding)
+        }
+
+        val twoArraysString = """{"padding": [[1, 2], [3, 4]]}"""
+        (klaxon.parse<LayerConfig>(twoArraysString)!!.padding as KerasPadding.ZeroPadding2D).apply {
+            assertArrayEquals(intArrayOf(1, 2, 3, 4), padding)
+        }
+    }
+
+    @Test
+    fun serializeStringPaddings() {
+        var serializedConfig: String
+        var jsonObject: JsonObject
+
+        val paddingValidConfig = LayerConfig(padding = KerasPadding.Valid)
+        serializedConfig = klaxon.toJsonString(paddingValidConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        assertEquals("valid", jsonObject["padding"])
+
+        val paddingSameConfig = LayerConfig(padding = KerasPadding.Same)
+        serializedConfig = klaxon.toJsonString(paddingSameConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        assertEquals("same", jsonObject["padding"])
+
+        val paddingFullConfig = LayerConfig(padding = KerasPadding.Full)
+        serializedConfig = klaxon.toJsonString(paddingFullConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        assertEquals("full", jsonObject["padding"])
+    }
+
+    @Test
+    fun serializeZeroPaddingValues() {
+        var serializedConfig: String
+        var jsonObject: JsonObject
+
+        var layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(intArrayOf(1)))
+        serializedConfig = klaxon.toJsonString(layerConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        assertEquals(1, jsonObject["padding"])
+
+        layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(intArrayOf(1, 2)))
+        serializedConfig = klaxon.toJsonString(layerConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        assertArrayEquals(intArrayOf(1, 2), jsonObject.array<Int>("padding")!!.toIntArray())
+
+        layerConfig = LayerConfig(padding = KerasPadding.ZeroPadding2D(intArrayOf(1, 2, 3, 4)))
+        serializedConfig = klaxon.toJsonString(layerConfig)
+        jsonObject = parser.parse(StringBuilder(serializedConfig)) as JsonObject
+        val parsedArray = jsonObject.array<JsonArray<Int>>("padding")!!
+        assertArrayEquals(intArrayOf(1, 2), parsedArray[0].toIntArray())
+        assertArrayEquals(intArrayOf(3, 4), parsedArray[1].toIntArray())
+    }
+}


### PR DESCRIPTION
This is the implementation of `ZeroPadding2D` layer. The usage of this layer can be found at tensorflow implementation of Resnet (see https://github.com/tensorflow/tensorflow/blob/582c8d236cb079023657287c318ff26adb239002/tensorflow/python/keras/applications/resnet.py#L175).

This layer has the following structure in `.json` configs:
`{
        "class_name": "ZeroPadding2D",
        "config": {
          "name": "conv1_pad",
          "trainable": true,
          "dtype": "float32",
          "padding": [[3,3], [3,3]],
          "data_format": "channels_last"
}`
As its `config.padding` has different type than `Convolution`/`Pooling` layers, I suggest to use `KerasPadding` class instead of plain `String` in `LayerConfig`. A custom json converter class `PaddingConverter` is used to maintain different `padding` set-ups.
 