### PR TITLE
Add AbstractConv documentation

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -137,7 +137,6 @@ public abstract class AbstractConv(
      *  Defaults to the number of filter in convolutional layer. */
     protected open fun getOutputDepth(numberOfChannels: Long): Long = filtersInternal
 
-
     /**
      * Define the [kernelShape] by default from its [kernelSizeInternal],
      * [filtersInternal] and the given [numberOfChannels] from input Tensor.
@@ -155,7 +154,6 @@ public abstract class AbstractConv(
      */
     protected open fun computeBiasShape(numberOfChannels: Long): Shape =
         Shape.make(filtersInternal)
-
 
     /** Given a layer name specify its kernel name. */
     protected abstract fun kernelVarName(name: String): String

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -21,29 +21,29 @@ import kotlin.math.roundToInt
 
 /**
  * Abstract Convolutional layer is a base block for building base types of convolutional layers
- * of any dimensionality. It should simplify the internal calculations needed in most of
- * the convolutional layers and abstract the process of naming weights for these layers. It keeps
- * the actual implementation of convolutional layers i.e. the kernel and bias learnable variables
- * that should be used in child classes in actual implementations of these layers. If the child class
+ * of any dimensionality. It should simplify the internal calculations needed in most convolutional
+ * layers and abstract the naming weights for these layers. It keeps the actual implementation
+ * of convolutional layers, i.e., the kernel and bias learnable variables that should
+ * be used in child classes in actual implementations of these layers. If the child class
  * uses some values for its implementation in other form than it is kept in this child class,
  * then this abstract class `internal` properties should keep the implementation values
  * while the child class properties should keep the printable values that are more representative.
- * But in most cases the `internal` and child values will be the same.
+ * But in most cases, the `internal` and child values will be the same.
  *
- * @property filtersInternal number used by default in calculation of layer weights and i/o shapes
- * @property kernelSizeInternal numbers used by default in calculation of layer weights and i/o shapes
- * @property stridesInternal numbers used by default in calculation of layer weights and i/o shapes
- * @property dilationsInternal numbers to keep for the dilations for implementation
- * @property activationInternal activation used in [forward] operation implementation
- * @property kernelInitializerInternal kernelInitializer used in actual kernel variable filling implementation
- * @property biasInitializerInternal biasInitializer used in actual bias variable filling implementation
- * @property kernelRegularizerInternal kernelRegularizer used in actual kernel variable filling implementation
- * @property biasRegularizerInternal biasRegularizer used in actual bias variable filling implementation
- * @property activityRegularizerInternal regularizer function applied to the output of the layer
- * @property paddingInternal numbers to keep for the padding for implementation
- * @property useBiasInternal flag if bias should be used during actual [forward] implementation
- * @property kernelVariableName name of kernel used when no layer name is defined
- * @property biasVariableName name of bias used when no layer name is defined
+ * @property [filtersInternal] number used by default in calculation of layer weights and i/o shapes
+ * @property [kernelSizeInternal] numbers used by default in calculation of layer weights and i/o shapes
+ * @property [stridesInternal] numbers used by default in calculation of layer weights and i/o shapes
+ * @property [dilationsInternal] numbers to keep for the dilations for implementation
+ * @property [activationInternal] activation used in [forward] operation implementation
+ * @property [kernelInitializerInternal] initializer used in actual kernel variable filling implementation
+ * @property [biasInitializerInternal] initializer used in actual bias variable filling implementation
+ * @property [kernelRegularizerInternal] regularizer function used in actual kernel variable filling implementation
+ * @property [biasRegularizerInternal] regularizer function used in actual bias variable filling implementation
+ * @property [activityRegularizerInternal] regularizer function applied to the output of the layer
+ * @property [paddingInternal] numbers to keep for the padding for implementation
+ * @property [useBiasInternal] flag if bias should be used during actual [forward] implementation
+ * @property [kernelVariableName] name of kernel used when no layer name is defined
+ * @property [biasVariableName] name of bias used when no layer name is defined
  * @constructor Creates [AbstractConv] object
  *
  * @param name of the layer to name its variables
@@ -66,10 +66,10 @@ public abstract class AbstractConv(
     name: String
 ) : Layer(name) {
 
-    /** Tensor with learnable variables for kernel defined by internal shapes */
+    /** Tensor with kernel weights */
     protected lateinit var kernel: Variable<Float>
 
-    /** Tensor with learnable variables for bias defined by internal shapes */
+    /** Tensor with bias weights */
     protected var bias: Variable<Float>? = null
 
     /** Shape of internal implementation of kernel variable */
@@ -83,7 +83,8 @@ public abstract class AbstractConv(
         val numberOfChannels = inputShape.size(inputShape.numDimensions() - 1)
 
         // Compute shapes of kernel and bias matrices
-        computeMatricesShapes(numberOfChannels)
+        kernelShape = computeKernelShape(numberOfChannels)
+        biasShape = computeBiasShape(numberOfChannels)
 
         // should be calculated before addWeight because it's used in calculation
         val inputDepth = numberOfChannels // number of input channels
@@ -136,16 +137,25 @@ public abstract class AbstractConv(
      *  Defaults to the number of filter in convolutional layer. */
     protected open fun getOutputDepth(numberOfChannels: Long): Long = filtersInternal
 
+
     /**
-     * Define the [kernelShape] and [biasShape] by default from its [kernelSizeInternal],
-     * [filtersInternal], [filtersInternal] and the given [numberOfChannels] from input Tensor.
+     * Define the [kernelShape] by default from its [kernelSizeInternal],
+     * [filtersInternal] and the given [numberOfChannels] from input Tensor.
      *
      * @param numberOfChannels for input of this layer
      */
-    protected open fun computeMatricesShapes(numberOfChannels: Long) {
-        kernelShape = shapeFromDims(*kernelSizeInternal, numberOfChannels, filtersInternal)
-        biasShape = Shape.make(filtersInternal)
-    }
+    protected open fun computeKernelShape(numberOfChannels: Long): Shape =
+        shapeFromDims(*kernelSizeInternal, numberOfChannels, filtersInternal)
+
+    /**
+     * Define the [biasShape] by default from its [filtersInternal] and
+     * the given [numberOfChannels] from input Tensor.
+     *
+     * @param numberOfChannels for input of this layer
+     */
+    protected open fun computeBiasShape(numberOfChannels: Long): Shape =
+        Shape.make(filtersInternal)
+
 
     /** Given a layer name specify its kernel name. */
     protected abstract fun kernelVarName(name: String): String

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -23,7 +23,7 @@ import kotlin.math.roundToInt
  * Abstract Convolutional layer is a base block for building base types of convolutional layers
  * of any dimensionality. It should simplify the internal calculations needed in most of
  * the convolutional layers and abstract the process of naming weights for these layers. It keeps
- * the actual implementation of convolutional layers e.i. the kernel and bias learnable variables
+ * the actual implementation of convolutional layers i.e. the kernel and bias learnable variables
  * that should be used in child classes in actual implementations of these layers. If the child class
  * uses some values for its implementation in other form than it is kept in this child class,
  * then this abstract class `internal` properties should keep the implementation values

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -95,6 +95,8 @@ public class Conv1D(
         requireArraySize(dilations, 3, "dilations")
     }
 
+    /** Axis of height for which the extra dimension is added (unsqueezed) before actual
+     * convolution operation and on which the output from actual implementation is squeezed */
     private val squeezeAxis = Squeeze.axis(listOf(EXTRA_DIM))
 
     override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 1)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -96,7 +96,7 @@ public class Conv1D(
     }
 
     /** Axis of height for which the extra dimension is added (unsqueezed) before actual
-     * convolution operation and on which the output from actual implementation is squeezed */
+     * convolution operation and the output from actual implementation are squeezed. */
     private val squeezeAxis = Squeeze.axis(listOf(EXTRA_DIM))
 
     override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 1)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
@@ -92,10 +92,11 @@ public class DepthwiseConv2D(
         isTrainable = false
     }
 
-    override fun computeMatricesShapes(numberOfChannels: Long) {
-        kernelShape = shapeFromDims(*kernelSize, numberOfChannels, depthMultiplier.toLong())
-        biasShape = Shape.make(numberOfChannels * depthMultiplier)
-    }
+    protected override fun computeKernelShape(numberOfChannels: Long): Shape =
+        shapeFromDims(*kernelSize, numberOfChannels, depthMultiplier.toLong())
+
+    protected override fun computeBiasShape(numberOfChannels: Long): Shape =
+        Shape.make(numberOfChannels * depthMultiplier)
 
     override fun getOutputDepth(numberOfChannels: Long): Long = numberOfChannels * depthMultiplier
 


### PR DESCRIPTION
Resolves #118. Adding the documentation only for parent class seems to be good enough and that's the reason I did'n provide the documentation for `build`, `forward` etc. as the documentation is present in `Layer`.

@zaleslaw If you can try to look at the description of `AbstractConv` because I'm not sure if I was able to express my intention in a readable way so it maybe should be improved