### PR TITLE
Permute Layer

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Permute.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Permute.kt
@@ -1,0 +1,55 @@
+package org.jetbrains.kotlinx.dl.api.core.layer.core
+
+import org.jetbrains.kotlinx.dl.api.core.KGraph
+import org.jetbrains.kotlinx.dl.api.core.layer.Layer
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.tensorflow.Operand
+import org.tensorflow.Shape
+import org.tensorflow.op.Ops
+
+/**
+ * Permutes the dimensions of the input according to a given pattern.
+ * Input shape: Arbitrary
+ * Output shape: Same as input shape, but with the dimensions re-ordered according to the specified pattern.
+ * @property [dims] array of integers.
+ * @property [name] Custom layer name.
+ * @constructor Creates [Permute] object.
+ */
+public class Permute(
+    public val dims: IntArray,
+    name: String
+) : Layer(name) {
+    override fun build(tf: Ops, kGraph: KGraph, inputShape: Shape) {}
+
+    override fun computeOutputShape(inputShape: Shape): Shape {
+        val outputShape = LongArray(dims.size + 1) { 0 }
+        dims.forEachIndexed { i, dim ->
+            val target_dim = inputShape.size(dim);
+            outputShape[i + 1] = target_dim
+        }
+        return TensorShape(outputShape).toShape()
+    }
+
+    override fun forward(
+        tf: Ops,
+        input: Operand<Float>,
+        isTraining: Operand<Boolean>,
+        numberOfLosses: Operand<Float>?
+    ): Operand<Float> {
+        val permArray = intArrayOf(0) + dims
+        val perm = tf.constant(permArray)
+        return tf.linalg.transpose(input, perm);
+    }
+
+    override var weights: Map<String, Array<*>>
+        get() = emptyMap()
+        set(value) = assignWeights(value)
+
+    override val hasActivation: Boolean get() = false
+
+    override val paramCount: Int get() = 0
+
+    override fun toString(): String {
+        return "Permute(name=$name)"
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
 package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.KGraph
@@ -58,6 +62,6 @@ public class Permute(
     override val paramCount: Int get() = 0
 
     override fun toString(): String {
-        return "Permute(name=$name)"
+        return "Permute(name=$name, dims=$dims)"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/Permute.kt
@@ -1,8 +1,9 @@
-package org.jetbrains.kotlinx.dl.api.core.layer.core
+package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 
 import org.jetbrains.kotlinx.dl.api.core.KGraph
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
+import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
@@ -19,15 +20,22 @@ public class Permute(
     public val dims: IntArray,
     name: String
 ) : Layer(name) {
+
+    init {
+        require(dims.sorted() == (1..dims.size).toList()) {
+            "The values in dims should be consecutive and start from 1."
+        }
+    }
+
     override fun build(tf: Ops, kGraph: KGraph, inputShape: Shape) {}
 
     override fun computeOutputShape(inputShape: Shape): Shape {
-        val outputShape = LongArray(dims.size + 1) { 0 }
+        val outputShape = inputShape.toLongArray()
         dims.forEachIndexed { i, dim ->
-            val target_dim = inputShape.size(dim);
+            val target_dim = inputShape.size(dim)
             outputShape[i + 1] = target_dim
         }
-        return TensorShape(outputShape).toShape()
+        return shapeFromDims(*outputShape)
     }
 
     override fun forward(
@@ -38,7 +46,7 @@ public class Permute(
     ): Operand<Float> {
         val permArray = intArrayOf(0) + dims
         val perm = tf.constant(permArray)
-        return tf.linalg.transpose(input, perm);
+        return tf.linalg.transpose(input, perm)
     }
 
     override var weights: Map<String, Array<*>>

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstants.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstants.kt
@@ -10,6 +10,7 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 internal const val LAYER_DENSE: String = "Dense"
 internal const val LAYER_INPUT: String = "InputLayer"
 internal const val LAYER_ACTIVATION: String = "Activation"
+internal const val LAYER_PERMUTE: String = "Permute"
 // Convolution layers
 internal const val LAYER_CONV1D: String = "Conv1D"
 internal const val LAYER_CONV2D: String = "Conv2D"

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.*
 import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
-import org.jetbrains.kotlinx.dl.api.core.layer.core.Permute
+import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.Permute
 import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
 import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.*
 import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Permute
 import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
 import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*
@@ -113,6 +114,7 @@ private fun convertToLayer(
         // Core layers
         LAYER_ACTIVATION -> createActivationLayer(kerasLayer.config!!, kerasLayer.config.name!!)
         LAYER_DENSE -> createDenseLayer(kerasLayer.config!!, kerasLayer.config.name!!)
+        LAYER_PERMUTE -> createPermuteLayer(kerasLayer.config!!, kerasLayer.config.name!!)
         // Convolution layers
         LAYER_CONV1D -> createConv1DLayer(kerasLayer.config!!, kerasLayer.config.name!!)
         LAYER_CONV2D -> createConv2DLayer(kerasLayer.config!!, kerasLayer.config.name!!)
@@ -614,6 +616,13 @@ private fun createDenseLayer(config: LayerConfig, name: String): Layer {
         kernelRegularizer = convertToRegularizer(config.kernel_regularizer),
         biasRegularizer = convertToRegularizer(config.bias_regularizer),
         activityRegularizer = convertToRegularizer(config.activity_regularizer),
+        name = name
+    )
+}
+
+private fun createPermuteLayer(config: LayerConfig,name: String): Layer {
+    return Permute(
+        dims = config.dims!!,
         name = name
     )
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.*
 import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
-import org.jetbrains.kotlinx.dl.api.core.layer.core.Permute
+import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.Permute
 import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
 import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*
@@ -515,7 +515,8 @@ private fun createKerasDenseLayer(layer: Dense, isKerasFullyCompatible: Boolean)
 private fun createKerasPermuteLayer(layer: Permute):KerasLayer{
     val configX = LayerConfig(
         dims = layer.dims,
-        name = layer.name
+        name = layer.name,
+        trainable = layer.isTrainable
     )
     return KerasLayer(class_name = LAYER_PERMUTE, config = configX)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.*
 import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Permute
 import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
 import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*
@@ -72,6 +73,7 @@ private fun convertToKerasLayer(layer: Layer, isKerasFullyCompatible: Boolean, i
         is Input -> createKerasInputLayer(layer)
         is Dense -> createKerasDenseLayer(layer, isKerasFullyCompatible)
         is ActivationLayer -> createKerasActivationLayer(layer)
+        is Permute -> createKerasPermuteLayer(layer)
         // Convolution layers
         is Conv1D -> createKerasConv1DLayer(layer, isKerasFullyCompatible)
         is Conv2D -> createKerasConv2DLayer(layer, isKerasFullyCompatible)
@@ -508,6 +510,14 @@ private fun createKerasDenseLayer(layer: Dense, isKerasFullyCompatible: Boolean)
         activity_regularizer = convertToKerasRegularizer(layer.activityRegularizer),
     )
     return KerasLayer(class_name = LAYER_DENSE, config = configX)
+}
+
+private fun createKerasPermuteLayer(layer: Permute):KerasLayer{
+    val configX = LayerConfig(
+        dims = layer.dims,
+        name = layer.name
+    )
+    return KerasLayer(class_name = LAYER_PERMUTE, config = configX)
 }
 
 private fun createKerasMaxPool1DLayer(layer: MaxPool1D): KerasLayer {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
@@ -153,5 +153,7 @@ internal data class LayerConfig(
     @Json(serializeNull = false)
     val unroll: Boolean? = null,
     @Json(serializeNull = false)
-    val use_bias: Boolean? = null
+    val use_bias: Boolean? = null,
+    @Json(serializeNull = false)
+    val dims: IntArray? = null
 )

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PermuteTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/PermuteTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer
+
+import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.Permute
+import org.jetbrains.kotlinx.dl.api.core.shape.shape
+import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
+import org.junit.jupiter.api.Test
+
+internal class PermuteTest : LayerTest() {
+    private val input = arrayOf(
+        arrayOf(
+            floatArrayOf(0.0f, 1.0f),
+            floatArrayOf(2.0f, 3.0f),
+            floatArrayOf(4.0f, 5.0f)
+        )
+    )
+
+    private val inputShape = input.shape.toLongArray()
+
+    @Test
+    fun default() {
+        val layer = Permute(dims = intArrayOf(2, 1), name = "permuteTest")
+        val expected = arrayOf(
+            arrayOf(
+                floatArrayOf(0.0f, 2.0f, 4.0f),
+                floatArrayOf(1.0f, 3.0f, 5.0f)
+            )
+        )
+        assertLayerOutputIsCorrect(layer, input, expected)
+        val expectedShape = longArrayOf(inputShape[0], inputShape[2], inputShape[1])
+        assertLayerComputedOutputShape(layer, inputShape, expectedShape)
+    }
+}


### PR DESCRIPTION
This PR adds Permute Layer. Resolves #142.

TODO:
- [x] Add implementation of `Permute`
- [x] Export to ModelSaver and ModelLoader
- [x] Add Docs
- [x] Add unit tests 