### PR TITLE
Bugfix/161 correct temporary dataset path

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
@@ -262,7 +262,7 @@ public fun cifar10Paths(cacheDirectory: File = File("cache")): Pair<String, Stri
 }
 
 /** Path to the Dogs-vs-Cats dataset. */
-private const val DOGS_CATS_IMAGES_ARCHIVE: String = "datasets/catdogs/data.zip"
+private const val DOGS_CATS_IMAGES_ARCHIVE: String = "datasets/dogs-vs-cats/data.zip"
 
 /** Returns path to images of the Dogs-vs-Cats dataset. */
 public fun dogsCatsDatasetPath(cacheDirectory: File = File("cache")): String =

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
@@ -278,12 +278,15 @@ public fun dogsCatsDatasetPath(cacheDirectory: File = File("cache")): String =
 /** Path to the subset of Dogs-vs-Cats dataset. */
 private const val DOGS_CATS_SMALL_IMAGES_ARCHIVE: String = "datasets/small_catdogs/data.zip"
 
+/** Path to the Data.zip url to be downloaded from. */
+private const val DOGS_CATS_SMALL_IMAGES_DOWNLOAD_URL: String = "https://kotlindl.s3.amazonaws.com/datasets/small_catdogs/data.zip"
+
 /** Returns path to images of the subset of the Dogs-vs-Cats dataset. */
 public fun dogsCatsSmallDatasetPath(cacheDirectory: File = File("cache")): String =
     unzipDatasetPath(
         cacheDirectory,
-        loadFile(cacheDirectory, DOGS_CATS_SMALL_IMAGES_ARCHIVE),
-        "/datasets/small-dogs-vs-cats"
+        loadFile(cacheDirectory, DOGS_CATS_SMALL_IMAGES_ARCHIVE, downloadURLFromRelativePath = { DOGS_CATS_SMALL_IMAGES_DOWNLOAD_URL }),
+        "/datasets/small_catdogs"
     )
 
 /** Path to the Free Spoken Digits Dataset. */
@@ -321,6 +324,12 @@ private fun unzipDatasetPath(cacheDirectory: File, archive: File, dirRelativePat
     if (!dataDirectory.exists()) {
         Files.createDirectories(dataDirectory.toPath())
 
+        extractFromZipArchiveToFolder(archive.toPath(), toFolder)
+        val deleted = archive.delete()
+        if (!deleted) {
+            throw Exception("Archive ${archive.absolutePath} could not be deleted! Create this archive manually.")
+        }
+    } else {
         extractFromZipArchiveToFolder(archive.toPath(), toFolder)
         val deleted = archive.delete()
         if (!deleted) {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
@@ -276,7 +276,7 @@ public fun dogsCatsDatasetPath(cacheDirectory: File = File("cache")): String =
     )
 
 /** Path to the subset of Dogs-vs-Cats dataset. */
-private const val DOGS_CATS_SMALL_IMAGES_ARCHIVE: String = "datasets/small_catdogs/data.zip"
+private const val DOGS_CATS_SMALL_IMAGES_ARCHIVE: String = "datasets/small-dogs-vs-cats/data.zip"
 
 /** Path to the Data.zip url to be downloaded from. */
 private const val DOGS_CATS_SMALL_IMAGES_DOWNLOAD_URL: String = "https://kotlindl.s3.amazonaws.com/datasets/small_catdogs/data.zip"
@@ -286,7 +286,7 @@ public fun dogsCatsSmallDatasetPath(cacheDirectory: File = File("cache")): Strin
     unzipDatasetPath(
         cacheDirectory,
         loadFile(cacheDirectory, DOGS_CATS_SMALL_IMAGES_ARCHIVE, downloadURLFromRelativePath = { DOGS_CATS_SMALL_IMAGES_DOWNLOAD_URL }),
-        "/datasets/small_catdogs"
+        "/datasets/small-dogs-vs-cats"
     )
 
 /** Path to the Free Spoken Digits Dataset. */

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/embeddedDatasets.kt
@@ -264,11 +264,14 @@ public fun cifar10Paths(cacheDirectory: File = File("cache")): Pair<String, Stri
 /** Path to the Dogs-vs-Cats dataset. */
 private const val DOGS_CATS_IMAGES_ARCHIVE: String = "datasets/dogs-vs-cats/data.zip"
 
+/** Path to the Data.zip url to be downloaded from. */
+private const val DOGS_CATS_IMAGES_DOWNLOAD_URL: String = "https://kotlindl.s3.amazonaws.com/datasets/catdogs/data.zip"
+
 /** Returns path to images of the Dogs-vs-Cats dataset. */
 public fun dogsCatsDatasetPath(cacheDirectory: File = File("cache")): String =
     unzipDatasetPath(
         cacheDirectory,
-        loadFile(cacheDirectory, DOGS_CATS_IMAGES_ARCHIVE),
+        loadFile(cacheDirectory, DOGS_CATS_IMAGES_ARCHIVE, downloadURLFromRelativePath = { DOGS_CATS_IMAGES_DOWNLOAD_URL }),
         "/datasets/dogs-vs-cats"
     )
 

--- a/examples/src/test/kotlin/examples/cnn/dogscats/CatDogTestSuite.kt
+++ b/examples/src/test/kotlin/examples/cnn/dogscats/CatDogTestSuite.kt
@@ -5,10 +5,8 @@
 
 package examples.cnn.dogscats
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-@Disabled
 class CatDogTestSuite {
     @Test
     fun resnet50onCatDogDatasetTest() {

--- a/examples/src/test/kotlin/examples/cnn/dogscats/CatDogTestSuite.kt
+++ b/examples/src/test/kotlin/examples/cnn/dogscats/CatDogTestSuite.kt
@@ -5,8 +5,10 @@
 
 package examples.cnn.dogscats
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+@Disabled
 class CatDogTestSuite {
     @Test
     fun resnet50onCatDogDatasetTest() {


### PR DESCRIPTION
Now the data.zip is downloaded to the correct path.
This fixes the issue: Incorrect temporary folder for the cats-vs-dogs dataset [LINK](https://github.com/JetBrains/KotlinDL/issues/161)
fixes #161 