### PR TITLE
Fix typo in RandomUniform javadoc

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/initializer/RandomUniform.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/initializer/RandomUniform.kt
@@ -12,8 +12,8 @@ import org.tensorflow.op.Ops
 /**
  * Initializer that generates tensors with a uniform distribution.
  *
- * @property [maxVal] Lower bound of the range of random values to generate (inclusive).
- * @property [minVal] Upper bound of the range of random values to generate (exclusive).
+ * @property [minVal] Lower bound of the range of random values to generate (inclusive).
+ * @property [maxVal] Upper bound of the range of random values to generate (exclusive).
  * @property [seed] Used to create random seeds.
  * @constructor Creates a [RandomUniform] initializer.
  */


### PR DESCRIPTION
"minVal" and "maxVal" parameter descriptions were mixed up.