### PR TITLE
Do not use absolute paths for input and output images in PreprocessOnlyOneImage example

### DIFF
--- a/examples/src/main/kotlin/examples/dataset/PreprocessOnlyOneImage.kt
+++ b/examples/src/main/kotlin/examples/dataset/PreprocessOnlyOneImage.kt
@@ -27,11 +27,9 @@ import kotlin.math.min
  * - image visualisation
  */
 fun main() {
-    val image =
-        File("C:\\Users\\zaleslaw\\IdeaProjects\\KotlinDL\\examples\\src\\main\\resources\\datasets\\vgg\\image2.jpg")
-
-    val preprocessedImagesDirectory =
-        File("C:\\Users\\zaleslaw\\processedImages")
+    val imageResource = ImagePreprocessing::class.java.getResource("/datasets/vgg/image2.jpg")
+    val image = File(imageResource!!.toURI())
+    val preprocessedImagesDirectory = File("processedImages")
 
     val preprocessing: Preprocessing = preprocess {
         transformImage {


### PR DESCRIPTION
Fixes #196