### PR TITLE
Fixed minor code warnings

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/initializer/Orthogonal.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/initializer/Orthogonal.kt
@@ -61,7 +61,7 @@ public class Orthogonal(
         val n:Operand<Float>? = null
         if (numRows < numCols) qop = tf.withName(name).linalg.transpose(qop, n)
 
-        return tf.math.mul(tf.reshape(qop,shape), tf.dtypes.cast(tf.constant(this.gain), getDType()));
+        return tf.math.mul(tf.reshape(qop,shape), tf.dtypes.cast(tf.constant(this.gain), getDType()))
     }
 
     override fun toString(): String {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
@@ -15,7 +15,6 @@ import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Variable
-import java.lang.IllegalArgumentException
 
 /**
  * Base abstract class for all layers.

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -10,13 +10,14 @@ import org.jetbrains.kotlinx.dl.api.core.activation.Activations
 import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.*
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.shape.numElements
+import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.jetbrains.kotlinx.dl.api.core.util.getDType
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 import org.tensorflow.op.core.Variable
-import java.lang.IllegalArgumentException
 import kotlin.math.roundToInt
 
 /**

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
@@ -9,10 +9,9 @@ import org.jetbrains.kotlinx.dl.api.core.activation.Activations
 import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
 import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
 import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
-import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.*
+import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.jetbrains.kotlinx.dl.api.core.util.convBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convKernelVarName
 import org.tensorflow.Operand

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/ActivationLayer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/ActivationLayer.kt
@@ -5,13 +5,9 @@
 
 package org.jetbrains.kotlinx.dl.api.core.layer.core
 
-import org.jetbrains.kotlinx.dl.api.core.KGraph
 import org.jetbrains.kotlinx.dl.api.core.activation.Activations
-import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.activation.AbstractActivationLayer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.tensorflow.Operand
-import org.tensorflow.Shape
 import org.tensorflow.op.Ops
 
 /**

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/GlobalAvgPool3D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.KGraph
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.util.TF
-import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_LAST
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool2D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.pooling
 import org.jetbrains.kotlinx.dl.api.core.KGraph
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
-import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
 import org.tensorflow.Operand
 import org.tensorflow.Shape

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
@@ -4,9 +4,6 @@ import org.jetbrains.kotlinx.dl.api.core.KGraph
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.jetbrains.kotlinx.dl.api.core.shape.convOutputLength
-import org.jetbrains.kotlinx.dl.api.core.shape.shapeOperand
-import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_FIRST
-import org.jetbrains.kotlinx.dl.api.inference.keras.CHANNELS_LAST
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/pooling/MaxPool3D.kt
@@ -52,8 +52,8 @@ public class MaxPool3D(
     ): Operand<Float> {
         // TODO add dataFormat support
         val paddingName = padding.paddingName
-        var tfPoolSize = Arrays.stream(poolSize).asLongStream().toArray();
-        var tfStrides = Arrays.stream(strides).asLongStream().toArray();
+        var tfPoolSize = Arrays.stream(poolSize).asLongStream().toArray()
+        var tfStrides = Arrays.stream(strides).asLongStream().toArray()
         var tfInput: Operand<Float> = input
         var output = tf.nn.maxPool3d(tfInput, tfPoolSize.toList(), tfStrides.toList(), paddingName)
         return output

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/UpSampling1D.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.core.layer.reshaping
 import org.tensorflow.Operand
 import org.tensorflow.Shape
 import org.tensorflow.op.Ops
-import org.tensorflow.op.core.Squeeze
 
 /**
  * Upsampling layer for 1D input.

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding1D.kt
@@ -63,7 +63,7 @@ public class ZeroPadding1D : AbstractZeroPadding {
     }
 
     override fun computeOutputShape(inputShape: Shape): Shape {
-        val length = inputShape.size(1) + padding[0] + padding[1];
+        val length = inputShape.size(1) + padding[0] + padding[1]
         return Shape.make(inputShape.size(1), length, inputShape.size(2))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/reshaping/ZeroPadding3D.kt
@@ -85,9 +85,9 @@ public class ZeroPadding3D : AbstractZeroPadding {
     }
 
     override fun computeOutputShape(inputShape: Shape): Shape {
-        val dim1 = inputShape.size(1) + padding[0] + padding[1];
-        val dim2 = inputShape.size(2) + padding[2] + padding[3];
-        val dim3 = inputShape.size(3) + padding[4] + padding[5];
+        val dim1 = inputShape.size(1) + padding[0] + padding[1]
+        val dim2 = inputShape.size(2) + padding[2] + padding[3]
+        val dim3 = inputShape.size(3) + padding[4] + padding[5]
         return Shape.make(inputShape.size(0), dim1, dim2, dim3, inputShape.size(4))
     }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlinx.dl.api.inference.keras
 import com.beust.klaxon.Klaxon
 import org.jetbrains.kotlinx.dl.api.core.Functional
 import org.jetbrains.kotlinx.dl.api.core.GraphTrainableModel
-import org.jetbrains.kotlinx.dl.api.core.Sequential
 import org.jetbrains.kotlinx.dl.api.core.activation.Activations
 import org.jetbrains.kotlinx.dl.api.core.initializer.*
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
@@ -17,7 +16,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.*
 import org.jetbrains.kotlinx.dl.api.core.layer.core.ActivationLayer
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
-import org.jetbrains.kotlinx.dl.api.core.layer.reshaping.Permute
 import org.jetbrains.kotlinx.dl.api.core.layer.merge.*
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
 import org.jetbrains.kotlinx.dl.api.core.layer.pooling.*

--- a/dataset/build.gradle
+++ b/dataset/build.gradle
@@ -11,6 +11,10 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+kotlin {
+    explicitApiWarning()
+}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
1. Optimised imports.
2. Removed redundant semicolons at the end of statements.
3. Enabled warning for missing visibility modifiers to get rid of warnings for `public` modifiers. Now `OnHeapDataset.x` and `OnHeapDataset.y` are missing visibility modifiers, I did not know if they are supposed to be `internal` or `public`, so I did not add any yet.