### PR TITLE
reduced time complexity of FloatArray::argmax to linear

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/extension/FloatArrayExtensionFunctions.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/extension/FloatArrayExtensionFunctions.kt
@@ -38,4 +38,4 @@ public fun FloatArray.get2D(rowIndex: Int, columnIndex: Int, width: Int): Float 
  * TODO: Should be replaced with Multik in future.
  */
 public fun FloatArray.argmax(): Int =
-    this.indexOfFirst { it == this.maxOrNull()!! }
+    maxOrNull()?.let { max -> indexOfFirst { it == max } } ?: -1


### PR DESCRIPTION
Reduced time complexity of argmax method from O(n^2) to linear, also, since it is now a generic function, make it work with empty arrays