### PR TITLE
Remove redundant array initializers

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/Cifar10Util.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/Cifar10Util.kt
@@ -16,24 +16,18 @@ private const val DATASET_SIZE = 50000
 /** Loads images from [archiveName] to heap memory and applies basic normalization preprocessing. */
 @Throws(IOException::class)
 public fun extractCifar10Images(archiveName: String): Array<FloatArray> {
-    val numOfPixels: Int = 32 * 32 * 3
-
     return loadImagesFromDirectory(
-        numOfPixels,
         DATASET_SIZE,
         archiveName
     )
 }
 
 private fun loadImagesFromDirectory(
-    numOfPixels: Int,
     subDatasetSize: Int,
     archiveName: String
 ): Array<FloatArray> {
-    val images = Array(subDatasetSize) { FloatArray(numOfPixels) }
-
-    for (i in 1..50000) {
-        images[i - 1] = ImageConverter.toNormalizedFloatArray(File("$archiveName\\$i.png"))
+    val images = Array(subDatasetSize) {
+        ImageConverter.toNormalizedFloatArray(File("$archiveName\\${it + 1}.png"))
     }
 
     return images

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/FashionMnistUtil.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/FashionMnistUtil.kt
@@ -49,15 +49,10 @@ public fun extractFashionImages(archivePath: String): Array<FloatArray> {
             archivePath
         )
     )
-    val images =
-        Array(imageCount) { FloatArray(imageRows * imageCols) }
     val imageBuffer = ByteArray(imageRows * imageCols)
-    for (i in 0 until imageCount) {
+    val images = Array(imageCount) {
         archiveStream.readFully(imageBuffer)
-        images[i] =
-            OnHeapDataset.toNormalizedVector(
-                imageBuffer
-            )
+        OnHeapDataset.toNormalizedVector(imageBuffer)
     }
     return images
 }
@@ -78,14 +73,11 @@ public fun extractFashionLabels(archivePath: String, numClasses: Int): Array<Flo
     println(String.format("Extracting %d labels from %s", labelCount, archivePath))
     val labelBuffer = ByteArray(labelCount)
     archiveStream.readFully(labelBuffer)
-    val floats =
-        Array(labelCount) { FloatArray(numClasses) }
-    for (i in 0 until labelCount) {
-        floats[i] =
-            OnHeapDataset.toOneHotVector(
-                numClasses,
-                labelBuffer[i]
-            )
+    val floats = Array(labelCount) {
+        OnHeapDataset.toOneHotVector(
+            numClasses,
+            labelBuffer[it]
+        )
     }
     return floats
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/MnistUtil.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/handler/MnistUtil.kt
@@ -51,15 +51,10 @@ public fun extractImages(archivePath: String): Array<FloatArray> {
             archivePath
         )
     )
-    val images =
-        Array(imageCount) { FloatArray(imageRows * imageCols) }
     val imageBuffer = ByteArray(imageRows * imageCols)
-    for (i in 0 until imageCount) {
+    val images = Array(imageCount) {
         archiveStream.readFully(imageBuffer)
-        images[i] =
-            OnHeapDataset.toNormalizedVector(
-                imageBuffer
-            )
+        OnHeapDataset.toNormalizedVector(imageBuffer)
     }
     return images
 }

--- a/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
+++ b/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/OnFlyImageDataset.kt
@@ -35,13 +35,7 @@ public class OnFlyImageDataset internal constructor(
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
     private fun copyImagesToBatch(src: Array<File>, start: Int, length: Int): Array<FloatArray> {
-        val numOfPixels: Int = 32 * 32 * 3
-
-        val dataForBatch = Array(length) { FloatArray(numOfPixels) { 0.0f } }
-        for (i in start until start + length) {
-            dataForBatch[i - start] = applyImagePreprocessing(src[i])
-        }
-        return dataForBatch
+        return Array(length) { index -> applyImagePreprocessing(src[start + index]) }
     }
 
     private fun applyImagePreprocessing(file: File): FloatArray {
@@ -50,11 +44,7 @@ public class OnFlyImageDataset internal constructor(
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
     private fun copyLabelsToBatch(src: FloatArray, start: Int, length: Int): FloatArray {
-        val dataForBatch = FloatArray(length) { 0.0f }
-        for (i in start until start + length) {
-            dataForBatch[i - start] = src[i]
-        }
-        return dataForBatch
+        return FloatArray(length) { src[start + it] }
     }
 
     /** Splits datasets on two sub-datasets according [splitRatio].*/

--- a/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
+++ b/dataset/src/main/kotlin/org/jetbrains/kotlinx/dl/dataset/OnHeapDataset.kt
@@ -27,9 +27,8 @@ public class OnHeapDataset internal constructor(val x: Array<FloatArray>, val y:
 
     /** Converts [src] to [FloatBuffer] from [start] position for the next [length] positions. */
     private fun copyXToBatch(src: Array<FloatArray>, start: Int, length: Int): Array<FloatArray> {
-        val dataForBatch = Array(length) { FloatArray(src[0].size) { 0.0f } }
-        for (i in start until start + length) {
-            dataForBatch[i - start] = src[i].copyOf() // Creates new copy for batch data
+        val dataForBatch = Array(length) {
+            src[it + start].copyOf()
         }
         return dataForBatch
     }
@@ -185,7 +184,7 @@ public class OnHeapDataset internal constructor(val x: Array<FloatArray>, val y:
                 val loading = preprocessors.imagePreprocessingStage.load
                 val xFiles = loading.prepareFileNames()
 
-                val x = prepareX(xFiles, preprocessors, preprocessors.finalShape.numberOfElements.toInt())
+                val x = prepareX(xFiles, preprocessors)
 
                 OnHeapDataset(x, labels)
             } catch (e: IOException) {
@@ -195,14 +194,9 @@ public class OnHeapDataset internal constructor(val x: Array<FloatArray>, val y:
 
         private fun prepareX(
             xFiles: Array<File>,
-            preprocessors: Preprocessing,
-            numOfPixels: Int
+            preprocessors: Preprocessing
         ): Array<FloatArray> {
-            val x = Array(xFiles.size) { FloatArray(numOfPixels) { 0.0f } }
-            for (i in xFiles.indices) {
-                x[i] = preprocessors.handleFile(xFiles[i]).first
-            }
-            return x
+            return Array(xFiles.size) { preprocessors.handleFile(xFiles[it]).first }
         }
 
 
@@ -217,8 +211,7 @@ public class OnHeapDataset internal constructor(val x: Array<FloatArray>, val y:
             return try {
                 val loading = preprocessors.imagePreprocessingStage.load
                 val xFiles = loading.prepareFileNames()
-                val numOfPixels = preprocessors.finalShape.numberOfElements.toInt()
-                val x = prepareX(xFiles, preprocessors, numOfPixels)
+                val x = prepareX(xFiles, preprocessors)
                 val y = prepareY(xFiles, preprocessors)
 
                 OnHeapDataset(x, y)


### PR DESCRIPTION
There is a number of places in the code where the following pattern is used:
```
val array = Array(length) { /*initializer*/ }
for ( i in 0 until length) {
  array[i] = /*other initializer*/
}
```
Sometimes the first initializer creates another array, which is then thrown out in the `for`-cycle. 
This commit fixes such places in the code.