### PR TITLE
Add transpose convolution layers

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Layer.kt
@@ -165,3 +165,11 @@ internal fun IntArray.toLongArray(): LongArray {
         else -> LongArray(size) { this[it].toLong() }
     }
 }
+
+internal fun LongArray.toIntArray(): IntArray {
+    return when (size) {
+        0 -> intArrayOf()
+        1 -> intArrayOf(this[0].toInt())
+        else -> IntArray(size) { this[it].toInt() }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -26,43 +26,41 @@ import kotlin.math.roundToInt
  * of any dimensionality. It should simplify the internal calculations needed in most convolutional
  * layers and abstract the naming weights for these layers. It keeps the actual implementation
  * of convolutional layers, i.e., the kernel and bias learnable variables that should
- * be used in child classes in actual implementations of these layers. If the child class
- * uses some values for its implementation in other form than it is kept in this child class,
- * then this abstract class `internal` properties should keep the implementation values
- * while the child class properties should keep the printable values that are more representative.
- * But in most cases, the `internal` and child values will be the same.
+ * be used in child classes in actual implementations of these layers.
  *
- * @property [filtersInternal] number used by default in calculation of layer weights and i/o shapes
- * @property [kernelSizeInternal] numbers used by default in calculation of layer weights and i/o shapes
- * @property [stridesInternal] numbers used by default in calculation of layer weights and i/o shapes
- * @property [dilationsInternal] numbers to keep for the dilations for implementation
- * @property [activationInternal] activation used in [forward] operation implementation
- * @property [kernelInitializerInternal] initializer used in actual kernel variable filling implementation
- * @property [biasInitializerInternal] initializer used in actual bias variable filling implementation
- * @property [kernelRegularizerInternal] regularizer function used in actual kernel variable filling implementation
- * @property [biasRegularizerInternal] regularizer function used in actual bias variable filling implementation
- * @property [activityRegularizerInternal] regularizer function applied to the output of the layer
- * @property [paddingInternal] numbers to keep for the padding for implementation
- * @property [useBiasInternal] flag if bias should be used during actual [forward] implementation
+ * @property [filters] number used by default in calculation of layer weights and i/o shapes
+ * @property [kernelSize] numbers used by default in calculation of layer weights and i/o shapes
+ * @property [strides] numbers used by default in calculation of layer weights and i/o shapes
+ * @property [dilations] numbers to keep for the dilations for implementation
+ * @property [activation] activation used in [forward] operation implementation
+ * @property [kernelInitializer] initializer used in actual kernel variable filling implementation
+ * @property [biasInitializer] initializer used in actual bias variable filling implementation
+ * @property [kernelRegularizer] regularizer function used in actual kernel variable filling implementation
+ * @property [biasRegularizer] regularizer function used in actual bias variable filling implementation
+ * @property [activityRegularizer] regularizer function applied to the output of the layer
+ * @property [padding] numbers to keep for the padding for implementation
+ * @property [useBias] flag if bias should be used during actual [forward] implementation
  * @constructor Creates [AbstractConv] object
  *
  * @param name of the layer to name its variables
  */
 public abstract class AbstractConv(
-    protected val filtersInternal: Int,
-    protected val kernelSizeInternal: IntArray,
-    protected val stridesInternal: IntArray,
-    protected val dilationsInternal: IntArray,
-    protected val activationInternal: Activations,
-    protected val kernelInitializerInternal: Initializer,
-    protected val biasInitializerInternal: Initializer,
-    protected val kernelRegularizerInternal: Regularizer?,
-    protected val biasRegularizerInternal: Regularizer?,
-    protected val activityRegularizerInternal: Regularizer?,
-    protected val paddingInternal: ConvPadding,
-    protected val useBiasInternal: Boolean,
     name: String
 ) : Layer(name) {
+    
+    protected abstract val filters: Int
+    protected abstract val kernelSize: IntArray
+    protected abstract val strides: IntArray
+    protected abstract val dilations: IntArray
+    protected abstract val activation: Activations
+    protected abstract val kernelInitializer: Initializer
+    protected abstract val biasInitializer: Initializer
+    protected abstract val kernelRegularizer: Regularizer?
+    protected abstract val biasRegularizer: Regularizer?
+    protected abstract val activityRegularizer: Regularizer?
+    protected abstract val padding: ConvPadding
+    protected abstract val useBias: Boolean
+
     /** Tensor with kernel weights */
     protected lateinit var kernel: KVariable
 
@@ -75,9 +73,9 @@ public abstract class AbstractConv(
 
         val inputDepth = numberOfChannels // number of input channels
         val outputDepth = getOutputDepth(numberOfChannels) // number of output channels
-        val fanIn = (inputDepth * multiply(kernelSizeInternal.toLongArray())).toInt()
-        val fanOut = ((outputDepth * multiply(kernelSizeInternal.toLongArray())).toDouble() /
-                     multiply(stridesInternal.toLongArray()).toDouble()).roundToInt()
+        val fanIn = (inputDepth * multiply(kernelSize.toLongArray())).toInt()
+        val fanOut = ((outputDepth * multiply(kernelSize.toLongArray())).toDouble() /
+                     multiply(strides.toLongArray()).toDouble()).roundToInt()
 
         kernel = createVariable(
             tf,
@@ -87,11 +85,11 @@ public abstract class AbstractConv(
             computeKernelShape(numberOfChannels),
             fanIn,
             fanOut,
-            kernelInitializerInternal,
-            kernelRegularizerInternal
+            kernelInitializer,
+            kernelRegularizer
         )
 
-        if (useBiasInternal) {
+        if (useBias) {
             bias = createVariable(
                 tf,
                 kGraph,
@@ -100,8 +98,8 @@ public abstract class AbstractConv(
                 computeBiasShape(numberOfChannels),
                 fanIn,
                 fanOut,
-                biasInitializerInternal,
-                biasRegularizerInternal
+                biasInitializer,
+                biasRegularizer
             )
         }
     }
@@ -122,7 +120,7 @@ public abstract class AbstractConv(
 
         val withBias = bias?.let { tf.nn.biasAdd(convolution, it.variable) } ?: convolution
 
-        return Activations.convert(activationInternal).apply(tf, withBias, name)
+        return Activations.convert(activation).apply(tf, withBias, name)
     }
 
     /** Returns the shape of kernel weights. */
@@ -142,25 +140,25 @@ public abstract class AbstractConv(
 
     /** Define the number of output channels given the number of input channels.
      *  Defaults to the number of filter in convolutional layer. */
-    protected open fun getOutputDepth(numberOfChannels: Long): Long = filtersInternal.toLong()
+    protected open fun getOutputDepth(numberOfChannels: Long): Long = filters.toLong()
 
     /**
-     * Define the [kernel] shape by default from its [kernelSizeInternal],
-     * [filtersInternal] and the given [numberOfChannels] from input Tensor.
+     * Define the [kernel] shape by default from its [kernelSize],
+     * [filters] and the given [numberOfChannels] from input Tensor.
      *
      * @param numberOfChannels for input of this layer
      */
     protected open fun computeKernelShape(numberOfChannels: Long): Shape =
-        shapeFromDims(*kernelSizeInternal.toLongArray(), numberOfChannels, filtersInternal.toLong())
+        shapeFromDims(*kernelSize.toLongArray(), numberOfChannels, filters.toLong())
 
     /**
-     * Define the [bias] shape by default from its [filtersInternal] and
+     * Define the [bias] shape by default from its [filters] and
      * the given [numberOfChannels] from input Tensor.
      *
      * @param numberOfChannels for input of this layer
      */
     protected open fun computeBiasShape(numberOfChannels: Long): Shape =
-        Shape.make(filtersInternal.toLong())
+        Shape.make(filters.toLong())
 
     /** Given a layer name specify its kernel name. */
     protected abstract fun kernelVarName(name: String): String

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -59,7 +59,7 @@ public abstract class AbstractConv(
     protected abstract val biasRegularizer: Regularizer?
     protected abstract val activityRegularizer: Regularizer?
     protected abstract val padding: ConvPadding
-    protected abstract val useBias: Boolean
+    internal abstract val useBias: Boolean
 
     /** Tensor with kernel weights */
     protected lateinit var kernel: KVariable

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -72,9 +72,9 @@ public class Conv1D(
     name: String = "",
 ) : AbstractConv(
     filtersInternal = filters,
-    kernelSizeInternal = intArrayOf(1, kernelSize),
-    stridesInternal = intArrayOf(strides[0], 1, strides[1], strides[2]),
-    dilationsInternal = intArrayOf(dilations[0], 1, dilations[1], dilations[2]),
+    kernelSizeInternal = intArrayOf(kernelSize),
+    stridesInternal = strides,
+    dilationsInternal = dilations,
     activationInternal = activation,
     kernelInitializerInternal = kernelInitializer,
     biasInitializerInternal = biasInitializer,
@@ -102,10 +102,13 @@ public class Conv1D(
         tf: Ops,
         input: Operand<Float>
     ): Operand<Float> {
-        val options = Conv2d.dilations(dilationsInternal.toLongList()).dataFormat("NHWC")
         val reshapedInput = tf.expandDims(input, tf.constant(EXTRA_DIM))
+        val expandedKernel = tf.expandDims(kernel.variable, tf.constant(EXTRA_DIM - 1))
+        val expandedStrides = intArrayOf(stridesInternal[0], 1, stridesInternal[1], stridesInternal[2])
+        val expandedDilations = intArrayOf(dilationsInternal[0], 1, dilationsInternal[1], dilationsInternal[2])
+        val options = Conv2d.dilations(expandedDilations.toLongList()).dataFormat("NHWC")
         val result = tf.nn.conv2d(
-            reshapedInput, kernel.variable, stridesInternal.toLongList(), paddingInternal.paddingName, options
+            reshapedInput, expandedKernel, expandedStrides.toLongList(), paddingInternal.paddingName, options
         )
         return tf.squeeze(result, squeezeAxis)
     }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.ex
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.expandKernel
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.withAdded
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.withExpandedDimensions
-import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2DTranspose.Companion.withStandardPadding
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
@@ -88,8 +87,8 @@ public class Conv1DTranspose(
                 tf.expandKernel(kernel.variable),
                 expandedInput,
                 expand(strides).toLongList(),
-                if (outputPadding != null) Conv2DTranspose.EXPLICIT else padding.paddingName,
-                *Conv2DTranspose.buildOptions(
+                if (outputPadding != null) EXPLICIT else padding.paddingName,
+                *buildOptions(
                     expand(dilations),
                     expandedOutputPadding?.withStandardPadding(
                         padding,

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1DTranspose.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.convolutional
+
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
+import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.EXTRA_DIM
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.expand
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.expandKernel
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.withAdded
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1D.Companion.withExpandedDimensions
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2DTranspose.Companion.withStandardPadding
+import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
+import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
+import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.tensorflow.Operand
+import org.tensorflow.op.Ops
+
+/**
+ * 1D convolution transpose layer.
+ *
+ * This is an operation going in the opposite direction of a normal convolution:
+ * it transforms a tensor shaped like an output of some convolution into tensor that has the shape of the input.
+ *
+ * This layer expects input data of size `(N, L, C)` where
+ * ```
+ * N - batch size
+ * L - length of signal sequence
+ * C - number of channels
+ * ```
+ *
+ * Note: dilation values greater than 1 are not supported on cpu
+ * (see https://github.com/tensorflow/tensorflow/issues/28264).
+ *
+ * @property [filters] dimensionality of the output space (i.e. the number of filters in the convolution)
+ * @property [kernelLength] size of the convolutional kernel (one number)
+ * @property [strides] strides of the convolution for each dimension of the input tensor (three numbers)
+ * @property [dilations] dilations of the convolution for each dimension of the input tensor (three numbers).
+ *           Currently, dilation values greater than 1 are not supported on cpu.
+ * @property [activation] activation function
+ * @property [kernelInitializer] initializer for the kernel
+ * @property [biasInitializer] initializer for the bias
+ * @property [kernelRegularizer] regularizer for the kernel
+ * @property [biasRegularizer] regularizer for the bias
+ * @property [activityRegularizer] regularizer function applied to the output of the layer
+ * @property [padding] type of padding to use
+ * @property [outputPadding] the amount of explicit padding to use (six numbers: two for each dimension).
+ * @property [useBias] a flag that specifies if the bias should be used
+ * @param [name] custom layer name
+ */
+public class Conv1DTranspose(
+    public override val filters: Int = 3,
+    public val kernelLength: Int = 3,
+    public override val strides: IntArray = intArrayOf(1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
+    public override val kernelInitializer: Initializer = HeNormal(),
+    public override val biasInitializer: Initializer = HeUniform(),
+    public override val kernelRegularizer: Regularizer? = null,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val outputPadding: IntArray? = null,
+    public override val useBias: Boolean = true,
+    name: String = ""
+) : ConvTranspose(dimensions = 1, name), NoGradients {
+
+    init {
+        requireArraySize(strides, dimensions + 2, "strides")
+        requireArraySize(dilations, dimensions + 2, "dilations")
+        if (outputPadding != null) requireArraySize(outputPadding, 2 * (dimensions + 2), "outputPadding")
+        isTrainable = false
+    }
+
+    override val kernelSize: IntArray = intArrayOf(kernelLength)
+
+    override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        return tf.withExpandedDimensions(input) { expandedInput ->
+            val expandedOutputPadding = outputPadding?.withAdded(EXTRA_DIM * 2, listOf(0, 0))
+            return@withExpandedDimensions tf.nn.conv2dBackpropInput(
+                tf.shapeWithDynamicBatchSize(expand(outputShape), input),
+                tf.expandKernel(kernel.variable),
+                expandedInput,
+                expand(strides).toLongList(),
+                if (outputPadding != null) Conv2DTranspose.EXPLICIT else padding.paddingName,
+                *Conv2DTranspose.buildOptions(
+                    expand(dilations),
+                    expandedOutputPadding?.withStandardPadding(
+                        padding,
+                        expandKernel(kernelSize),
+                        expand(dilations)
+                    )
+                )
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
@@ -52,34 +52,21 @@ import org.tensorflow.op.nn.Conv2d.dilations
  * @constructor Creates [Conv2D] object.
  */
 public class Conv2D(
-    public val filters: Int = 32,
-    public val kernelSize: IntArray = intArrayOf(3, 3),
-    public val strides: IntArray = intArrayOf(1, 1, 1, 1),
-    public val dilations: IntArray = intArrayOf(1, 1, 1, 1),
-    public val activation: Activations = Activations.Relu,
-    public val kernelInitializer: Initializer = HeNormal(),
-    public val biasInitializer: Initializer = HeUniform(),
-    public val kernelRegularizer: Regularizer? = null,
-    public val biasRegularizer: Regularizer? = null,
-    public val activityRegularizer: Regularizer? = null,
-    public val padding: ConvPadding = ConvPadding.SAME,
-    public val useBias: Boolean = true,
+    public override val filters: Int = 32,
+    public override val kernelSize: IntArray = intArrayOf(3, 3),
+    public override val strides: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
+    public override val kernelInitializer: Initializer = HeNormal(),
+    public override val biasInitializer: Initializer = HeUniform(),
+    public override val kernelRegularizer: Regularizer? = null,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val useBias: Boolean = true,
     name: String = ""
-) : AbstractConv(
-    filtersInternal = filters,
-    kernelSizeInternal = kernelSize,
-    stridesInternal = strides,
-    dilationsInternal = dilations,
-    activationInternal = activation,
-    kernelInitializerInternal = kernelInitializer,
-    biasInitializerInternal = biasInitializer,
-    kernelRegularizerInternal = kernelRegularizer,
-    biasRegularizerInternal = biasRegularizer,
-    activityRegularizerInternal = activityRegularizer,
-    paddingInternal = padding,
-    useBiasInternal = useBias,
-    name = name
-) {
+) : AbstractConv(name = name) {
+
     init {
         requireArraySize(kernelSize, 2, "kernelSize")
         requireArraySize(strides, 4, "strides")
@@ -90,12 +77,12 @@ public class Conv2D(
         tf: Ops,
         input: Operand<Float>
     ): Operand<Float> {
-        val options = dilations(dilationsInternal.toLongList()).dataFormat("NHWC")
+        val options = dilations(dilations.toLongList()).dataFormat("NHWC")
         return tf.nn.conv2d(
             input,
             kernel.variable,
-            stridesInternal.toLongList(),
-            paddingInternal.paddingName,
+            strides.toLongList(),
+            padding.paddingName,
             options
         )
     }
@@ -107,20 +94,20 @@ public class Conv2D(
 
         val rows = convOutputLength(
             rowsCount,
-            kernelSizeInternal[0],
-            paddingInternal,
-            stridesInternal[1],
-            dilationsInternal[1]
+            kernelSize[0],
+            padding,
+            strides[1],
+            dilations[1]
         )
         val cols = convOutputLength(
             colsCount,
-            kernelSizeInternal[1],
-            paddingInternal,
-            stridesInternal[2],
-            dilationsInternal[2]
+            kernelSize[1],
+            padding,
+            strides[2],
+            dilations[2]
         )
 
-        return Shape.make(batchSize, rows, cols, filtersInternal.toLong())
+        return Shape.make(batchSize, rows, cols, filters.toLong())
     }
 
     override fun kernelVarName(name: String): String = convKernelVarName(name, dim = 2)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.convolutional
+
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
+import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
+import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
+import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
+import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeSingleSidePadding
+import org.tensorflow.Operand
+import org.tensorflow.op.Ops
+import org.tensorflow.op.nn.Conv2dBackpropInput
+
+/**
+ * 2D convolution transpose layer.
+ *
+ * This is an operation going in the opposite direction of a normal convolution:
+ * it transforms a tensor shaped like an output of some convolution into tensor that has the shape of the input.
+ *
+ * This layer expects input data of size `(N, H, W, C)` where
+ * ```
+ * N - batch size
+ * H - height
+ * W - width
+ * C - number of channels
+ * ```
+ *
+ * Note: dilation values greater than 1 are not supported on cpu
+ * (see https://github.com/tensorflow/tensorflow/issues/28264).
+ *
+ * @property [filters] dimensionality of the output space (i.e. the number of filters in the convolution)
+ * @property [kernelSize] size of the convolutional kernel (two numbers)
+ * @property [strides] strides of the convolution for each dimension of the input tensor (four numbers)
+ * @property [dilations] dilations of the convolution for each dimension of the input tensor (four numbers).
+ *           Currently, dilation values greater than 1 are not supported on cpu.
+ * @property [activation] activation function
+ * @property [kernelInitializer] initializer for the kernel
+ * @property [biasInitializer] initializer for the bias
+ * @property [kernelRegularizer] regularizer for the kernel
+ * @property [biasRegularizer] regularizer for the bias
+ * @property [activityRegularizer] regularizer function applied to the output of the layer
+ * @property [padding] type of padding to use
+ * @property [outputPadding] the amount of explicit padding to use (eight numbers: two for each dimension).
+ * @property [useBias] a flag that specifies if the bias should be used
+ * @param [name] custom layer name
+ */
+public class Conv2DTranspose(
+    public override val filters: Int = 3,
+    public override val kernelSize: IntArray = intArrayOf(3, 3),
+    public override val strides: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
+    public override val kernelInitializer: Initializer = HeNormal(),
+    public override val biasInitializer: Initializer = HeUniform(),
+    public override val kernelRegularizer: Regularizer? = null,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val outputPadding: IntArray? = null,
+    public override val useBias: Boolean = true,
+    name: String = ""
+) : ConvTranspose(dimensions = 2, name), NoGradients {
+
+    init {
+        requireArraySize(kernelSize, dimensions, "kernelSize")
+        requireArraySize(strides, dimensions + 2, "strides")
+        requireArraySize(dilations, dimensions + 2, "dilations")
+        if (outputPadding != null) requireArraySize(outputPadding, 2 * (dimensions + 2), "outputPadding")
+        isTrainable = false
+    }
+
+    override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        return tf.nn.conv2dBackpropInput(
+            tf.shapeWithDynamicBatchSize(outputShape, input),
+            kernel.variable,
+            input,
+            strides.toLongList(),
+            if (outputPadding != null) EXPLICIT else padding.paddingName,
+            *buildOptions(
+                dilations,
+                outputPadding?.withStandardPadding(
+                    padding,
+                    kernelSize,
+                    dilations
+                )
+            )
+        )
+    }
+
+    internal companion object {
+        internal const val EXPLICIT = "EXPLICIT"
+
+        /**
+         * Combines explicitly provided padding value with the standard padding from the provided padding method.
+         * This is needed since [org.tensorflow.op.NnOps.conv2dBackpropInput] function does not support specifying
+         * both padding method and explicit output padding at the same time.
+         */
+        internal fun IntArray.withStandardPadding(padding: ConvPadding,
+                                                  kernelSize: IntArray,
+                                                  dilations: IntArray
+        ): IntArray {
+            val withStandardPadding = kernelSize.indices.flatMap { dim ->
+                listOf(
+                    convTransposeSingleSidePadding(padding, this[2 * dim], kernelSize[dim], dilations[dim + 1]),
+                    convTransposeSingleSidePadding(padding, this[2 * dim + 1], kernelSize[dim], dilations[dim + 1])
+                )
+            }
+            return intArrayOf(0, 0, *(withStandardPadding.toIntArray()), 0, 0)
+        }
+
+        internal fun buildOptions(dilations: IntArray, outputPadding: IntArray?): Array<Conv2dBackpropInput.Options> {
+            val options = mutableListOf(Conv2dBackpropInput.dilations(dilations.toLongList()))
+            if (outputPadding != null) {
+                options.add(Conv2dBackpropInput.explicitPaddings(outputPadding.toLongList()))
+            }
+            return options.map { it.dataFormat("NHWC") }.toTypedArray()
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2DTranspose.kt
@@ -13,10 +13,8 @@ import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeSingleSidePadding
 import org.tensorflow.Operand
 import org.tensorflow.op.Ops
-import org.tensorflow.op.nn.Conv2dBackpropInput
 
 /**
  * 2D convolution transpose layer.
@@ -92,35 +90,5 @@ public class Conv2DTranspose(
                 )
             )
         )
-    }
-
-    internal companion object {
-        internal const val EXPLICIT = "EXPLICIT"
-
-        /**
-         * Combines explicitly provided padding value with the standard padding from the provided padding method.
-         * This is needed since [org.tensorflow.op.NnOps.conv2dBackpropInput] function does not support specifying
-         * both padding method and explicit output padding at the same time.
-         */
-        internal fun IntArray.withStandardPadding(padding: ConvPadding,
-                                                  kernelSize: IntArray,
-                                                  dilations: IntArray
-        ): IntArray {
-            val withStandardPadding = kernelSize.indices.flatMap { dim ->
-                listOf(
-                    convTransposeSingleSidePadding(padding, this[2 * dim], kernelSize[dim], dilations[dim + 1]),
-                    convTransposeSingleSidePadding(padding, this[2 * dim + 1], kernelSize[dim], dilations[dim + 1])
-                )
-            }
-            return intArrayOf(0, 0, *(withStandardPadding.toIntArray()), 0, 0)
-        }
-
-        internal fun buildOptions(dilations: IntArray, outputPadding: IntArray?): Array<Conv2dBackpropInput.Options> {
-            val options = mutableListOf(Conv2dBackpropInput.dilations(dilations.toLongList()))
-            if (outputPadding != null) {
-                options.add(Conv2dBackpropInput.explicitPaddings(outputPadding.toLongList()))
-            }
-            return options.map { it.dataFormat("NHWC") }.toTypedArray()
-        }
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
@@ -55,34 +55,21 @@ import org.tensorflow.op.nn.Conv3d.dilations
  * @since 0.3
  */
 public class Conv3D(
-    public val filters: Int = 32,
-    public val kernelSize: IntArray = intArrayOf(3, 3, 3),
-    public val strides: IntArray = intArrayOf(1, 1, 1, 1, 1),
-    public val dilations: IntArray = intArrayOf(1, 1, 1, 1, 1),
-    public val activation: Activations = Activations.Relu,
-    public val kernelInitializer: Initializer = HeNormal(),
-    public val biasInitializer: Initializer = HeUniform(),
-    public val kernelRegularizer: Regularizer? = null,
-    public val biasRegularizer: Regularizer? = null,
-    public val activityRegularizer: Regularizer? = null,
-    public val padding: ConvPadding = ConvPadding.SAME,
-    public val useBias: Boolean = true,
+    public override val filters: Int = 32,
+    public override val kernelSize: IntArray = intArrayOf(3, 3, 3),
+    public override val strides: IntArray = intArrayOf(1, 1, 1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
+    public override val kernelInitializer: Initializer = HeNormal(),
+    public override val biasInitializer: Initializer = HeUniform(),
+    public override val kernelRegularizer: Regularizer? = null,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val useBias: Boolean = true,
     name: String = ""
-) : AbstractConv(
-    filtersInternal = filters,
-    kernelSizeInternal = kernelSize,
-    stridesInternal = strides,
-    dilationsInternal = dilations,
-    activationInternal = activation,
-    kernelInitializerInternal = kernelInitializer,
-    biasInitializerInternal = biasInitializer,
-    kernelRegularizerInternal = kernelRegularizer,
-    biasRegularizerInternal = biasRegularizer,
-    activityRegularizerInternal = activityRegularizer,
-    paddingInternal = padding,
-    useBiasInternal = useBias,
-    name = name
-) {
+) : AbstractConv(name = name) {
+
     init {
         requireArraySize(kernelSize, 3, "kernelSize")
         requireArraySize(strides, 5, "strides")
@@ -98,12 +85,12 @@ public class Conv3D(
         tf: Ops,
         input: Operand<Float>
     ): Operand<Float> {
-        val options = dilations(dilationsInternal.toLongList()).dataFormat("NDHWC")
+        val options = dilations(dilations.toLongList()).dataFormat("NDHWC")
         return tf.nn.conv3d(
             input,
             kernel.variable,
-            stridesInternal.toLongList(),
-            paddingInternal.paddingName,
+            strides.toLongList(),
+            padding.paddingName,
             options
         )
     }
@@ -116,27 +103,27 @@ public class Conv3D(
 
         val depths = convOutputLength(
             depthsCount,
-            kernelSizeInternal[0],
-            paddingInternal,
-            stridesInternal[1],
-            dilationsInternal[1]
+            kernelSize[0],
+            padding,
+            strides[1],
+            dilations[1]
         )
         val rows = convOutputLength(
             rowsCount,
-            kernelSizeInternal[1],
-            paddingInternal,
-            stridesInternal[2],
-            dilationsInternal[2]
+            kernelSize[1],
+            padding,
+            strides[2],
+            dilations[2]
         )
         val cols = convOutputLength(
             colsCount,
-            kernelSizeInternal[2],
-            paddingInternal,
-            stridesInternal[3],
-            dilationsInternal[3]
+            kernelSize[2],
+            padding,
+            strides[3],
+            dilations[3]
         )
 
-        return Shape.make(batchSize, depths, rows, cols, filtersInternal.toLong())
+        return Shape.make(batchSize, depths, rows, cols, filters.toLong())
     }
 
     override fun toString(): String {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3DTranspose.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.convolutional
+
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeNormal
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.initializer.Initializer
+import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
+import org.jetbrains.kotlinx.dl.api.core.layer.requireArraySize
+import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
+import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
+import org.tensorflow.Operand
+import org.tensorflow.op.Ops
+import org.tensorflow.op.nn.Conv3dBackpropInput
+
+/**
+ * 3D convolution transpose layer.
+ *
+ * This is an operation going in the opposite direction of a normal convolution:
+ * it transforms a tensor shaped like an output of some convolution into tensor that has the shape of the input.
+ *
+ * This layer expects input data of size `(N, D, H, W, C)` where
+ * ```
+ * N - batch size
+ * D - depth
+ * H - height
+ * W - width
+ * C - number of channels
+ * ```
+ *
+ * Note: providing explicit output padding is currently not supported.
+ * Dilation values greater than 1 are not supported on cpu.
+ *
+ * @param [filters] dimensionality of the output space (i.e. the number of filters in the convolution)
+ * @property [kernelSize] size of the convolutional kernel (three numbers)
+ * @property [strides] strides of the convolution for each dimension of the input tensor (five numbers)
+ * @property [dilations] dilations of the convolution for each dimension of the input tensor (five numbers).
+ *           Currently, dilation values greater than 1 are not supported on cpu.
+ * @param [activation] activation function
+ * @param [kernelInitializer] initializer for the kernel
+ * @param [biasInitializer] initializer for the bias
+ * @param [kernelRegularizer] regularizer for the kernel
+ * @param [biasRegularizer] regularizer for the bias
+ * @param [activityRegularizer] regularizer function applied to the output of the layer
+ * @param [padding] type of padding to use
+ * @param [useBias] a flag that specifies if the bias should be used
+ * @param [name] custom layer name
+ */
+public class Conv3DTranspose(
+    public override val filters: Int = 3,
+    public override val kernelSize: IntArray = intArrayOf(3, 3, 3),
+    public override val strides: IntArray = intArrayOf(1, 1, 1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
+    public override val kernelInitializer: Initializer = HeNormal(),
+    public override val biasInitializer: Initializer = HeUniform(),
+    public override val kernelRegularizer: Regularizer? = null,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val useBias: Boolean = true,
+    name: String = ""
+) : ConvTranspose(dimensions = 3, name), NoGradients {
+    init {
+        requireArraySize(kernelSize, dimensions, "kernelSize")
+        requireArraySize(strides, dimensions + 2, "strides")
+        requireArraySize(dilations, dimensions + 2, "dilations")
+        isTrainable = false
+    }
+
+    override val outputPadding: IntArray? get() = null
+
+    override fun convImplementation(tf: Ops, input: Operand<Float>): Operand<Float> {
+        val options = Conv3dBackpropInput.dilations(dilations.toLongList()).dataFormat("NDHWC")
+        return tf.nn.conv3dBackpropInput(
+            tf.shapeWithDynamicBatchSize(outputShape, input),
+            kernel.variable,
+            input,
+            strides.toLongList(),
+            padding.paddingName,
+            options
+        )
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.toLongArray
 import org.jetbrains.kotlinx.dl.api.core.layer.toLongList
 import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeOutputLength
-import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeSingleSidePadding
+import org.jetbrains.kotlinx.dl.api.core.shape.convTransposePadding
 import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
 import org.jetbrains.kotlinx.dl.api.core.util.convTransposeBiasVarName
 import org.jetbrains.kotlinx.dl.api.core.util.convTransposeKernelVarName
@@ -94,9 +94,12 @@ public abstract class ConvTranspose(
             dilations: IntArray
         ): IntArray {
             val withStandardPadding = kernelSize.indices.flatMap { dim ->
-                listOf(
-                    convTransposeSingleSidePadding(padding, this[2 * dim], kernelSize[dim], dilations[dim + 1]),
-                    convTransposeSingleSidePadding(padding, this[2 * dim + 1], kernelSize[dim], dilations[dim + 1])
+                convTransposePadding(
+                    padding,
+                    this[2 * dim],
+                    this[2 * dim + 1],
+                    kernelSize[dim],
+                    dilations[dim + 1]
                 )
             }
             return intArrayOf(0, 0, *(withStandardPadding.toIntArray()), 0, 0)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/ConvTranspose.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer.convolutional
+
+import org.jetbrains.kotlinx.dl.api.core.layer.toLongArray
+import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
+import org.jetbrains.kotlinx.dl.api.core.shape.convTransposeOutputLength
+import org.jetbrains.kotlinx.dl.api.core.shape.shapeFromDims
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeBiasVarName
+import org.jetbrains.kotlinx.dl.api.core.util.convTransposeKernelVarName
+import org.tensorflow.Operand
+import org.tensorflow.Shape
+import org.tensorflow.op.Ops
+
+/**
+ * A base class for defining transposed convolution layers (sometimes called deconvolution) of different dimensions.
+ *
+ * This is an operation going in the opposite direction of a normal convolution:
+ * it transforms a tensor shaped like an output of some convolution into tensor that has the shape of the input.
+ *
+ * @property [dimensions] dimensionality of this convolution operation
+ * @property [outputPadding] the amount of padding to use for each dimension of the input tensor
+ * @param [name] custom layer name
+ */
+public abstract class ConvTranspose(
+    public val dimensions: Int,
+    name: String = ""
+) : AbstractConv(name = name) {
+
+    protected abstract val outputPadding: IntArray?
+
+    override fun defineOutputShape(inputShape: Shape): Shape {
+        val shapes = (kernelSize.indices).map {
+            convTransposeOutputLength(
+                inputShape.size(it + 1),
+                kernelSize[it],
+                padding,
+                outputPadding?.get(2 * (it + 1)),
+                outputPadding?.get(2 * (it + 1) + 1),
+                strides[it + 1],
+                dilations[it + 1]
+            )
+        }
+        return Shape.make(inputShape.size(0), *(shapes + filters.toLong()).toLongArray())
+    }
+
+    override fun kernelVarName(name: String): String = convTransposeKernelVarName(name, dimensions)
+    override fun biasVarName(name: String): String = convTransposeBiasVarName(name, dimensions)
+
+    protected override fun computeKernelShape(numberOfChannels: Long): Shape {
+        return shapeFromDims(*kernelSize.toLongArray(), filters.toLong(), numberOfChannels)
+    }
+
+    override fun toString(): String {
+        return "Conv${dimensions}DTranspose(" +
+                "filters=$filters, " +
+                "kernelSize=${kernelSize.contentToString()}, " +
+                "kernelShape=${kernel.shape}, " +
+                "biasShape=${bias?.shape}, " +
+                "strides=${strides.contentToString()}, " +
+                "dilations=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, " +
+                "biasInitializer=$biasInitializer, " +
+                "biasRegularizer=$biasRegularizer, " +
+                "kernelRegularizer=$kernelRegularizer, " +
+                "activityRegularizer=$activityRegularizer, " +
+                "padding=$padding, " +
+                "outputPadding=${outputPadding?.contentToString()} " +
+                ")"
+    }
+
+    internal companion object {
+        /**
+         * Creates an integer vector with the contents of [tensorShape], except for the first dimension (batch size):
+         * batch size from the [input] is used instead.
+         * This is needed as [org.tensorflow.op.NnOps.conv2dBackpropInput] and [org.tensorflow.op.NnOps.conv3dBackpropInput]
+         * need to have an exact shape provided, including batch size.
+         * Typically, when the layer is built, batch size is not known and [tensorShape] contains a "-1" instead.
+         * This why here a first value of the [input] shape is used, which is going to be known at runtime.
+         * See also [https://github.com/tensorflow/tensorflow/issues/833](https://github.com/tensorflow/tensorflow/issues/833)
+         */
+        internal fun Ops.shapeWithDynamicBatchSize(tensorShape: TensorShape, input: Operand<Float>): Operand<Int> {
+            val batchSize = squeeze(slice(shape(input), constant(intArrayOf(0)), constant(intArrayOf(1))))
+            val otherDims = tensorShape.dims().toList().drop(1).map { constant(it.toInt()) }
+            return stack(listOf(batchSize) + otherDims)
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
@@ -50,37 +50,20 @@ import org.tensorflow.op.nn.DepthwiseConv2dNative
  * @since 0.2
  */
 public class DepthwiseConv2D(
-    public val kernelSize: IntArray = intArrayOf(3, 3),
-    public val strides: IntArray = intArrayOf(1, 1, 1, 1),
-    public val dilations: IntArray = intArrayOf(1, 1, 1, 1),
-    public val activation: Activations = Activations.Relu,
+    public override val kernelSize: IntArray = intArrayOf(3, 3),
+    public override val strides: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val dilations: IntArray = intArrayOf(1, 1, 1, 1),
+    public override val activation: Activations = Activations.Relu,
     public val depthMultiplier: Int = 1,
     public val depthwiseInitializer: Initializer = HeNormal(),
-    public val biasInitializer: Initializer = HeUniform(),
+    public override val biasInitializer: Initializer = HeUniform(),
     public val depthwiseRegularizer: Regularizer? = null,
-    public val biasRegularizer: Regularizer? = null,
-    public val activityRegularizer: Regularizer? = null,
-    public val padding: ConvPadding = ConvPadding.SAME,
-    public val useBias: Boolean = true,
+    public override val biasRegularizer: Regularizer? = null,
+    public override val activityRegularizer: Regularizer? = null,
+    public override val padding: ConvPadding = ConvPadding.SAME,
+    public override val useBias: Boolean = true,
     name: String = ""
-) : AbstractConv(
-    // filtersInternal is not used in any place of this implementation of AbstractConv because
-    // all its usages are overridden with custom functions that use the depthMultiplier and the
-    // shape of the input data representing number of channels in it
-    filtersInternal = -1,
-    kernelSizeInternal = kernelSize,
-    stridesInternal = strides,
-    dilationsInternal = dilations,
-    activationInternal = activation,
-    kernelInitializerInternal = depthwiseInitializer,
-    biasInitializerInternal = biasInitializer,
-    kernelRegularizerInternal = depthwiseRegularizer,
-    biasRegularizerInternal = biasRegularizer,
-    activityRegularizerInternal = activityRegularizer,
-    paddingInternal = padding,
-    useBiasInternal = useBias,
-    name = name
-), NoGradients {
+) : AbstractConv(name = name), NoGradients {
 
     init {
         requireArraySize(kernelSize, 2, "kernelSize")
@@ -88,6 +71,13 @@ public class DepthwiseConv2D(
         requireArraySize(dilations, 4, "dilations")
         isTrainable = false
     }
+
+    // filters is not used in any place of this implementation of AbstractConv because
+    // all its usages are overridden with custom functions that use the depthMultiplier and the
+    // shape of the input data representing number of channels in it
+    override val filters: Int get() = -1
+    override val kernelInitializer: Initializer get() = depthwiseInitializer
+    override val kernelRegularizer: Regularizer? get() = depthwiseRegularizer
 
     protected override fun computeKernelShape(numberOfChannels: Long): Shape =
         shapeFromDims(*kernelSize.toLongArray(), numberOfChannels, depthMultiplier.toLong())
@@ -117,17 +107,17 @@ public class DepthwiseConv2D(
 
         val rows = convOutputLength(
             rowsCount,
-            kernelSizeInternal[0],
-            paddingInternal,
-            stridesInternal[1],
-            dilationsInternal[1]
+            kernelSize[0],
+            padding,
+            strides[1],
+            dilations[1]
         )
         val cols = convOutputLength(
             colsCount,
-            kernelSizeInternal[1],
-            paddingInternal,
-            stridesInternal[2],
-            dilationsInternal[2]
+            kernelSize[1],
+            padding,
+            strides[2],
+            dilations[2]
         )
         val filters = channelsCount * depthMultiplier
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/regularizer/L2L1.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/regularizer/L2L1.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -51,6 +51,10 @@ public open class L2L1(
             }
         }
         return regularization
+    }
+
+    override fun toString(): String {
+        return "L2L1(l1=$l1, l2=$l2)"
     }
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ConvUtil.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/shape/ConvUtil.kt
@@ -1,14 +1,27 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package org.jetbrains.kotlinx.dl.api.core.shape
 
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import java.lang.Integer.max
+
+private fun dilatedFilterSize(filterSize: Int, dilation: Int): Int {
+    return filterSize + (filterSize - 1) * (dilation - 1)
+}
+
+private fun ConvPadding.value(filterSize: Int): Int {
+    return when (this) {
+        ConvPadding.VALID -> 0
+        ConvPadding.SAME -> filterSize - 1
+        ConvPadding.FULL -> 2 * filterSize - 1
+    }
+}
 
 /**
- * Calculates output length.
+ * Calculates output length after applying convolution operation on a single axis.
  */
 internal fun convOutputLength(
     inputLength: Long,
@@ -17,11 +30,34 @@ internal fun convOutputLength(
     stride: Int,
     dilation: Int = 1
 ): Long {
-    val dilatedFilterSize = filterSize + (filterSize - 1) * (dilation - 1)
-    val outputLength = when (padding) {
-        ConvPadding.SAME -> inputLength
-        ConvPadding.VALID -> inputLength - dilatedFilterSize + 1
-        ConvPadding.FULL -> inputLength + dilatedFilterSize - 1
-    }
+    val dilatedFilterSize = dilatedFilterSize(filterSize, dilation)
+    val outputLength = inputLength - filterSize + 1 + padding.value(dilatedFilterSize)
     return ((outputLength + stride - 1).toFloat() / stride).toLong()
+}
+
+/**
+ * Calculates output length after applying transposed convolution operation on a single axis.
+ */
+internal fun convTransposeOutputLength(
+    inputLength: Long,
+    filterSize: Int,
+    padding: ConvPadding,
+    outputPaddingStart: Int?,
+    outputPaddingEnd: Int?,
+    stride: Int,
+    dilation: Int
+): Long {
+    val dilatedFilterSize = dilatedFilterSize(filterSize, dilation)
+    val totalPadding = (outputPaddingStart ?: 0) + (outputPaddingEnd ?: 0) - padding.value(dilatedFilterSize)
+    return (inputLength - 1) * stride + dilatedFilterSize + totalPadding
+}
+
+internal fun convTransposeSingleSidePadding(padding: ConvPadding,
+                                            outputPadding: Int,
+                                            filterSize: Int,
+                                            dilation: Int
+): Int {
+    val dilatedKernelSize = dilatedFilterSize(filterSize, dilation)
+    val automaticPadding = padding.value(dilatedKernelSize) / 2
+    return max(0, outputPadding - automaticPadding)
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/nameConventions.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/nameConventions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -29,6 +29,12 @@ internal fun convBiasVarName(name: String, dim: Int): String = layerVarName(name
 
 /** Default Conv kernel variable name in TensorFlow graph, based on layer's name. */
 internal fun convKernelVarName(name: String, dim: Int): String = layerVarName(name, "conv${dim}d_kernel")
+
+/** Default Conv transpose bias variable name in TensorFlow graph, based on layer's name. */
+internal fun convTransposeBiasVarName(name: String, dim: Int): String = layerVarName(name, "conv${dim}d_transpose_bias")
+
+/** Default Conv transpose kernel variable name in TensorFlow graph, based on layer's name. */
+internal fun convTransposeKernelVarName(name: String, dim: Int): String = layerVarName(name, "conv${dim}d_transpose_kernel")
 
 /** Default DepthwiseConv2d bias variable name in TensorFlow graph, based on layer's name. */
 internal fun depthwiseConv2dBiasVarName(name: String): String = layerVarName(name, "depthwise_conv2d_bias")

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstants.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/KerasConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -15,6 +15,9 @@ internal const val LAYER_PERMUTE: String = "Permute"
 internal const val LAYER_CONV1D: String = "Conv1D"
 internal const val LAYER_CONV2D: String = "Conv2D"
 internal const val LAYER_CONV3D: String = "Conv3D"
+internal const val LAYER_CONV1D_TRANSPOSE: String = "Conv1DTranspose"
+internal const val LAYER_CONV2D_TRANSPOSE: String = "Conv2DTranspose"
+internal const val LAYER_CONV3D_TRANSPOSE: String = "Conv3DTranspose"
 internal const val LAYER_DEPTHWISE_CONV2D: String = "DepthwiseConv2D"
 internal const val LAYER_SEPARABLE_CONV2D: String = "SeparableConv2D"
 // Pooling layers

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -505,105 +505,57 @@ private fun createPermuteLayer(config: LayerConfig): Layer {
 }
 
 private fun createMaxPool1DLayer(config: LayerConfig): Layer {
-    val poolSize = config.pool_size!!
-    val addedOnesPoolSize = intArrayOf(1, poolSize[0], 1)
-    val strides = config.strides!!
-    val addedOnesStrides = intArrayOf(1, strides[0], 1)
     return MaxPool1D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, config.pool_size!![0], 1),
+        strides = intArrayOf(1, config.strides!![0], 1),
         padding = convertPadding(config.padding!!)
     )
 }
 
 private fun createMaxPool2DLayer(config: LayerConfig): Layer {
     val poolSize = config.pool_size!!.toIntArray()
-    val addedOnesPoolSize = IntArray(4)
-    addedOnesPoolSize[0] = 1
-    addedOnesPoolSize[1] = poolSize[0]
-    addedOnesPoolSize[2] = poolSize[1]
-    addedOnesPoolSize[3] = 1
-
     val strides = config.strides!!.toIntArray()
-    val addedOnesStrides = IntArray(4)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = 1
-
     return MaxPool2D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, *poolSize, 1),
+        strides = intArrayOf(1, *strides, 1),
         padding = convertPadding(config.padding!!)
     )
 }
 
 private fun createAvgPool1DLayer(config: LayerConfig): Layer {
-    val poolSize = config.pool_size!!
-    val addedOnesPoolSize = intArrayOf(1, poolSize[0], 1)
-    val strides = config.strides!!
-    val addedOnesStrides = intArrayOf(1, strides[0], 1)
     return AvgPool1D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, config.pool_size!![0], 1),
+        strides = intArrayOf(1, config.strides!![0], 1),
         padding = convertPadding(config.padding!!)
     )
 }
 
 private fun createAvgPool2DLayer(config: LayerConfig): Layer {
     val poolSize = config.pool_size!!.toIntArray()
-    val addedOnesPoolSize = IntArray(4)
-    addedOnesPoolSize[0] = 1
-    addedOnesPoolSize[1] = poolSize[0]
-    addedOnesPoolSize[2] = poolSize[1]
-    addedOnesPoolSize[3] = 1
-
     val strides = config.strides!!.toIntArray()
-    val addedOnesStrides = IntArray(4)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = 1
-
     return AvgPool2D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, *poolSize, 1),
+        strides = intArrayOf(1, *strides, 1),
         padding = convertPadding(config.padding!!)
     )
 }
 
 private fun createAvgPool3DLayer(config: LayerConfig): Layer {
-    val poolSize = config.pool_size!!
-    val addedOnesPoolSize = intArrayOf(1, poolSize[0], poolSize[1], poolSize[2], 1)
-    val strides = config.strides!!
-    val addedOnesStrides = intArrayOf(1, strides[0], strides[1], strides[2], 1)
+    val poolSize = config.pool_size!!.toIntArray()
+    val strides = config.strides!!.toIntArray()
     return AvgPool3D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, *poolSize, 1),
+        strides = intArrayOf(1, *strides, 1),
         padding = convertPadding(config.padding!!)
     )
 }
 
 private fun createMaxPool3DLayer(config: LayerConfig): Layer {
     val poolSize = config.pool_size!!.toIntArray()
-    val addedOnesPoolSize = IntArray(5)
-    addedOnesPoolSize[0] = 1
-    addedOnesPoolSize[1] = poolSize[0]
-    addedOnesPoolSize[2] = poolSize[1]
-    addedOnesPoolSize[3] = poolSize[2]
-    addedOnesPoolSize[0] = 1
-
     val strides = config.strides!!.toIntArray()
-    val addedOnesStrides = IntArray(5)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = strides[2]
-    addedOnesStrides[4] = 1
-
     return MaxPool3D(
-        poolSize = addedOnesPoolSize,
-        strides = addedOnesStrides,
+        poolSize = intArrayOf(1, *poolSize, 1),
+        strides = intArrayOf(1, *strides, 1),
         padding = convertPadding(config.padding!!)
     )
 }
@@ -626,25 +578,11 @@ private fun createReshapeLayer(config: LayerConfig): Layer {
 }
 
 private fun createConv1DLayer(config: LayerConfig): Layer {
-    val kernelSize = config.kernel_size!![0]
-    val strides = config.strides!!
-
-    val addedOnesStrides = IntArray(3)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = 1
-
-    val dilation = config.dilation_rate!!
-    val addedOnesDilation = IntArray(3)
-    addedOnesDilation[0] = 1
-    addedOnesDilation[1] = dilation[0]
-    addedOnesDilation[2] = 1
-
     return Conv1D(
         filters = config.filters!!,
-        kernelSize = kernelSize,
-        strides = addedOnesStrides,
-        dilations = addedOnesDilation,
+        kernelSize = config.kernel_size!![0],
+        strides = intArrayOf(1, config.strides!![0], 1),
+        dilations = intArrayOf(1, config.dilation_rate!![0], 1),
         activation = convertToActivation(config.activation!!),
         kernelInitializer = convertToInitializer(config.kernel_initializer!!),
         biasInitializer = convertToInitializer(config.bias_initializer!!),
@@ -658,26 +596,13 @@ private fun createConv1DLayer(config: LayerConfig): Layer {
 
 private fun createConv2DLayer(config: LayerConfig): Layer {
     val kernelSize = config.kernel_size!!.toIntArray()
-    val strides = config.strides!!
-
-    val addedOnesStrides = IntArray(4)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = 1
-
-    val dilation = config.dilation_rate!!
-    val addedOnesDilation = IntArray(4)
-    addedOnesDilation[0] = 1
-    addedOnesDilation[1] = dilation[0]
-    addedOnesDilation[2] = dilation[1]
-    addedOnesDilation[3] = 1
-
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
     return Conv2D(
         filters = config.filters!!,
         kernelSize = kernelSize,
-        strides = addedOnesStrides,
-        dilations = addedOnesDilation,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
         activation = convertToActivation(config.activation!!),
         kernelInitializer = convertToInitializer(config.kernel_initializer!!),
         biasInitializer = convertToInitializer(config.bias_initializer!!),
@@ -691,28 +616,13 @@ private fun createConv2DLayer(config: LayerConfig): Layer {
 
 private fun createConv3DLayer(config: LayerConfig): Layer {
     val kernelSize = config.kernel_size!!.toIntArray()
-    val strides = config.strides!!
-
-    val addedOnesStrides = IntArray(5)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = strides[2]
-    addedOnesStrides[4] = 1
-
-    val dilation = config.dilation_rate!!
-    val addedOnesDilation = IntArray(5)
-    addedOnesDilation[0] = 1
-    addedOnesDilation[1] = dilation[0]
-    addedOnesDilation[2] = dilation[1]
-    addedOnesDilation[3] = dilation[2]
-    addedOnesDilation[4] = 1
-
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
     return Conv3D(
         filters = config.filters!!,
         kernelSize = kernelSize,
-        strides = addedOnesStrides,
-        dilations = addedOnesDilation,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
         activation = convertToActivation(config.activation!!),
         kernelInitializer = convertToInitializer(config.kernel_initializer!!),
         biasInitializer = convertToInitializer(config.bias_initializer!!),
@@ -726,25 +636,12 @@ private fun createConv3DLayer(config: LayerConfig): Layer {
 
 private fun createDepthwiseConv2DLayer(config: LayerConfig): Layer {
     val kernelSize = config.kernel_size!!.toIntArray()
-    val strides = config.strides!!
-
-    val addedOnesStrides = IntArray(4)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = 1
-
-    val dilation = config.dilation_rate!!
-    val addedOnesDilation = IntArray(4)
-    addedOnesDilation[0] = 1
-    addedOnesDilation[1] = dilation[0]
-    addedOnesDilation[2] = dilation[1]
-    addedOnesDilation[3] = 1
-
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
     return DepthwiseConv2D(
         kernelSize = kernelSize,
-        strides = addedOnesStrides,
-        dilations = addedOnesDilation,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
         activation = convertToActivation(config.activation!!),
         depthwiseInitializer = convertToInitializer(config.depthwise_initializer!!),
         depthMultiplier = config.depth_multiplier!!,
@@ -759,26 +656,14 @@ private fun createDepthwiseConv2DLayer(config: LayerConfig): Layer {
 
 private fun createSeparableConv2DLayer(config: LayerConfig): Layer {
     val kernelSize = config.kernel_size!!.toIntArray()
-    val strides = config.strides!!
-
-    val addedOnesStrides = IntArray(4)
-    addedOnesStrides[0] = 1
-    addedOnesStrides[1] = strides[0]
-    addedOnesStrides[2] = strides[1]
-    addedOnesStrides[3] = 1
-
-    val dilation = config.dilation_rate!!
-    val addedOnesDilation = IntArray(4)
-    addedOnesDilation[0] = 1
-    addedOnesDilation[1] = dilation[0]
-    addedOnesDilation[2] = dilation[1]
-    addedOnesDilation[3] = 1
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
 
     return SeparableConv2D(
         filters = config.filters!!,
         kernelSize = kernelSize,
-        strides = addedOnesStrides,
-        dilations = addedOnesDilation,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
         activation = convertToActivation(config.activation!!),
         depthwiseInitializer = convertToInitializer(config.depthwise_initializer!!),
         pointwiseInitializer = convertToInitializer(config.pointwise_initializer!!),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -82,6 +82,9 @@ private fun convertToLayer(
         LAYER_CONV1D -> createConv1DLayer(kerasLayer.config!!)
         LAYER_CONV2D -> createConv2DLayer(kerasLayer.config!!)
         LAYER_CONV3D -> createConv3DLayer(kerasLayer.config!!)
+        LAYER_CONV1D_TRANSPOSE -> createConv1DTransposeLayer(kerasLayer.config!!)
+        LAYER_CONV2D_TRANSPOSE -> createConv2DTransposeLayer(kerasLayer.config!!)
+        LAYER_CONV3D_TRANSPOSE -> createConv3DTransposeLayer(kerasLayer.config!!)
         LAYER_DEPTHWISE_CONV2D -> createDepthwiseConv2DLayer(kerasLayer.config!!)
         LAYER_SEPARABLE_CONV2D -> createSeparableConv2DLayer(kerasLayer.config!!)
         // Pooling layers
@@ -631,6 +634,73 @@ private fun createConv3DLayer(config: LayerConfig): Layer {
         activityRegularizer = convertToRegularizer(config.activity_regularizer),
         padding = convertPadding(config.padding!!),
         useBias = config.use_bias!!
+    )
+}
+
+private fun createConv1DTransposeLayer(config: LayerConfig): Layer {
+    return Conv1DTranspose(
+        filters = config.filters!!,
+        kernelLength = config.kernel_size!![0],
+        strides = intArrayOf(1, config.strides!![0], 1),
+        dilations = intArrayOf(1, config.dilation_rate!![0], 1),
+        activation = convertToActivation(config.activation!!),
+        kernelInitializer = convertToInitializer(config.kernel_initializer!!),
+        biasInitializer = convertToInitializer(config.bias_initializer!!),
+        kernelRegularizer = convertToRegularizer(config.kernel_regularizer),
+        biasRegularizer = convertToRegularizer(config.bias_regularizer),
+        activityRegularizer = convertToRegularizer(config.activity_regularizer),
+        padding = convertPadding(config.padding!!),
+        outputPadding = config.output_padding?.convertToOutputPadding(),
+        useBias = config.use_bias!!,
+    )
+}
+
+private fun createConv2DTransposeLayer(config: LayerConfig): Layer {
+    val kernelSize = config.kernel_size!!.toIntArray()
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
+    return Conv2DTranspose(
+        filters = config.filters!!,
+        kernelSize = kernelSize,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
+        activation = convertToActivation(config.activation!!),
+        kernelInitializer = convertToInitializer(config.kernel_initializer!!),
+        biasInitializer = convertToInitializer(config.bias_initializer!!),
+        kernelRegularizer = convertToRegularizer(config.kernel_regularizer),
+        biasRegularizer = convertToRegularizer(config.bias_regularizer),
+        activityRegularizer = convertToRegularizer(config.activity_regularizer),
+        padding = convertPadding(config.padding!!),
+        outputPadding = config.output_padding?.convertToOutputPadding(),
+        useBias = config.use_bias!!,
+    )
+}
+
+private fun createConv3DTransposeLayer(config: LayerConfig): Layer {
+    val kernelSize = config.kernel_size!!.toIntArray()
+    val strides = config.strides!!.toIntArray()
+    val dilation = config.dilation_rate!!.toIntArray()
+    return Conv3DTranspose(
+        filters = config.filters!!,
+        kernelSize = kernelSize,
+        strides = intArrayOf(1, *strides, 1),
+        dilations = intArrayOf(1, *dilation, 1),
+        activation = convertToActivation(config.activation!!),
+        kernelInitializer = convertToInitializer(config.kernel_initializer!!),
+        biasInitializer = convertToInitializer(config.bias_initializer!!),
+        kernelRegularizer = convertToRegularizer(config.kernel_regularizer),
+        biasRegularizer = convertToRegularizer(config.bias_regularizer),
+        activityRegularizer = convertToRegularizer(config.activity_regularizer),
+        padding = convertPadding(config.padding!!),
+        useBias = config.use_bias!!,
+    )
+}
+
+private fun List<Int>.convertToOutputPadding(): IntArray {
+    return intArrayOf(
+        0, 0,
+        *flatMap { padding -> listOf(padding / 2, padding - padding / 2) }.toIntArray(),
+        0, 0
     )
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -580,7 +580,7 @@ private fun createReshapeLayer(config: LayerConfig): Layer {
 private fun createConv1DLayer(config: LayerConfig): Layer {
     return Conv1D(
         filters = config.filters!!,
-        kernelSize = config.kernel_size!![0],
+        kernelLength = config.kernel_size!![0],
         strides = intArrayOf(1, config.strides!![0], 1),
         dilations = intArrayOf(1, config.dilation_rate!![0], 1),
         activation = convertToActivation(config.activation!!),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -662,7 +662,7 @@ private fun createKerasDotLayer(layer: Dot):KerasLayer{
 private fun createKerasConv1DLayer(layer: Conv1D, isKerasFullyCompatible: Boolean): KerasLayer {
     val configX = LayerConfig(
         filters = layer.filters,
-        kernel_size = listOf(layer.kernelSize),
+        kernel_size = listOf(layer.kernelLength),
         strides = listOf(layer.strides[1]),
         dilation_rate = listOf(layer.dilations[1]),
         activation = convertToKerasActivation(layer.activation),

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ModelSaver.kt
@@ -61,6 +61,9 @@ private fun convertToKerasLayer(layer: Layer, isKerasFullyCompatible: Boolean, i
         is Conv1D -> createKerasConv1DLayer(layer, isKerasFullyCompatible)
         is Conv2D -> createKerasConv2DLayer(layer, isKerasFullyCompatible)
         is Conv3D -> createKerasConv3DLayer(layer, isKerasFullyCompatible)
+        is Conv1DTranspose -> createKerasConv1DTransposeLayer(layer, isKerasFullyCompatible)
+        is Conv2DTranspose -> createKerasConv2DTransposeLayer(layer, isKerasFullyCompatible)
+        is Conv3DTranspose -> createKerasConv3DTransposeLayer(layer, isKerasFullyCompatible)
         is DepthwiseConv2D -> createKerasDepthwiseConv2DLayer(layer, isKerasFullyCompatible)
         is SeparableConv2D -> createKerasSeparableConv2DLayer(layer, isKerasFullyCompatible)
         // Pooling layers
@@ -649,7 +652,7 @@ private fun createKerasConcatenateLayer(layer: Concatenate): KerasLayer {
     return KerasLayer(class_name = LAYER_CONCATENATE, config = configX)
 }
 
-private fun createKerasDotLayer(layer: Dot):KerasLayer{
+private fun createKerasDotLayer(layer: Dot): KerasLayer {
     val configX = LayerConfig(
         dtype = DATATYPE_FLOAT32,
         axis = layer.axis,
@@ -716,6 +719,73 @@ private fun createKerasConv3DLayer(layer: Conv3D, isKerasFullyCompatible: Boolea
         use_bias = layer.useBias
     )
     return KerasLayer(class_name = LAYER_CONV3D, config = configX)
+}
+
+private fun createKerasConv1DTransposeLayer(layer: Conv1DTranspose, isKerasFullyCompatible: Boolean): KerasLayer {
+    val configX = LayerConfig(
+        filters = layer.filters,
+        kernel_size = listOf(layer.kernelLength),
+        strides = listOf(layer.strides[1]),
+        dilation_rate = listOf(layer.dilations[1]),
+        activation = convertToKerasActivation(layer.activation),
+        kernel_initializer = convertToKerasInitializer(layer.kernelInitializer, isKerasFullyCompatible),
+        bias_initializer = convertToKerasInitializer(layer.biasInitializer, isKerasFullyCompatible),
+        kernel_regularizer = convertToKerasRegularizer(layer.kernelRegularizer),
+        bias_regularizer = convertToKerasRegularizer(layer.biasRegularizer),
+        activity_regularizer = convertToKerasRegularizer(layer.activityRegularizer),
+        padding = convertToKerasPadding(layer.padding),
+        output_padding = layer.outputPadding?.convertToKerasOutputPadding(),
+        trainable = layer.isTrainable,
+        use_bias = layer.useBias,
+        name = layer.name
+    )
+    return KerasLayer(class_name = LAYER_CONV1D_TRANSPOSE, config = configX)
+}
+
+private fun createKerasConv2DTransposeLayer(layer: Conv2DTranspose, isKerasFullyCompatible: Boolean): KerasLayer {
+    val configX = LayerConfig(
+        filters = layer.filters,
+        kernel_size = layer.kernelSize.toList(),
+        strides = listOf(layer.strides[1], layer.strides[2]),
+        dilation_rate = listOf(layer.dilations[1], layer.dilations[2]),
+        activation = convertToKerasActivation(layer.activation),
+        kernel_initializer = convertToKerasInitializer(layer.kernelInitializer, isKerasFullyCompatible),
+        bias_initializer = convertToKerasInitializer(layer.biasInitializer, isKerasFullyCompatible),
+        kernel_regularizer = convertToKerasRegularizer(layer.kernelRegularizer),
+        bias_regularizer = convertToKerasRegularizer(layer.biasRegularizer),
+        activity_regularizer = convertToKerasRegularizer(layer.activityRegularizer),
+        padding = convertToKerasPadding(layer.padding),
+        output_padding = layer.outputPadding?.convertToKerasOutputPadding(),
+        trainable = layer.isTrainable,
+        use_bias = layer.useBias,
+        name = layer.name
+    )
+    return KerasLayer(class_name = LAYER_CONV2D_TRANSPOSE, config = configX)
+}
+
+private fun createKerasConv3DTransposeLayer(layer: Conv3DTranspose, isKerasFullyCompatible: Boolean): KerasLayer {
+    val configX = LayerConfig(
+        filters = layer.filters,
+        kernel_size = layer.kernelSize.toList(),
+        strides = listOf(layer.strides[1], layer.strides[2], layer.strides[3]),
+        dilation_rate = listOf(layer.dilations[1], layer.dilations[2], layer.dilations[3]),
+        activation = convertToKerasActivation(layer.activation),
+        kernel_initializer = convertToKerasInitializer(layer.kernelInitializer, isKerasFullyCompatible),
+        bias_initializer = convertToKerasInitializer(layer.biasInitializer, isKerasFullyCompatible),
+        kernel_regularizer = convertToKerasRegularizer(layer.kernelRegularizer),
+        bias_regularizer = convertToKerasRegularizer(layer.biasRegularizer),
+        activity_regularizer = convertToKerasRegularizer(layer.activityRegularizer),
+        padding = convertToKerasPadding(layer.padding),
+        name = layer.name,
+        use_bias = layer.useBias
+    )
+    return KerasLayer(class_name = LAYER_CONV3D_TRANSPOSE, config = configX)
+}
+
+private fun IntArray.convertToKerasOutputPadding(): List<Int> {
+    return (0 until (size - 4) / 2).map { dimension ->
+        get(2 * (dimension + 1)) + get(2 * (dimension + 1) + 1)
+    }
 }
 
 private fun createKerasDepthwiseConv2DLayer(layer: DepthwiseConv2D, isKerasFullyCompatible: Boolean): KerasLayer {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/config/LayerConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -94,6 +94,8 @@ internal data class LayerConfig(
     val negative_slope: Double? = null,
     @Json(serializeNull = false)
     val padding: KerasPadding? = null,
+    @Json(serializeNull = false)
+    val output_padding: List<Int>? = null,
     @Json(serializeNull = false)
     val pointwise_initializer: KerasInitializer? = null,
     @Json(serializeNull = false)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTest.kt
@@ -12,17 +12,10 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.junit.jupiter.api.Test
 
 internal class Conv1DTest : ConvLayerTest() {
-    private fun createFloatConv1DTensor(
-        batchSize: Int,
-        size: Int,
-        channels: Int,
-        initValue: Float
-    ) = Array(batchSize) { Array(size) { FloatArray(channels) { initValue } } }
-
     @Test
     fun zeroedInputTensorWithDefaultValues() {
-        val input = createFloatConv1DTensor(batchSize = 1, size = 3, channels = 1, initValue = 0.0f)
-        val expected = createFloatConv1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 0.0f)
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 1, initValue = 0.0f)
+        val expected = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 0.0f)
 
         assertTensorsEquals(
             Conv1D(
@@ -36,8 +29,8 @@ internal class Conv1DTest : ConvLayerTest() {
 
     @Test
     fun constantInputTensorWithValidPadding() {
-        val input = createFloatConv1DTensor(batchSize = 1, size = 3, channels = 1, initValue = 1.0f)
-        val expected = createFloatConv1DTensor(batchSize = 1, size = 2, channels = 16, initValue = 2.0f)
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 1, initValue = 1.0f)
+        val expected = create1DTensor(batchSize = 1, size = 2, channels = 16, initValue = 2.0f)
 
         assertTensorsEquals(
             Conv1D(
@@ -76,5 +69,20 @@ internal class Conv1DTest : ConvLayerTest() {
             input,
             expected
         )
+    }
+
+    companion object {
+        internal fun create1DTensor(
+            batchSize: Int,
+            size: Int,
+            channels: Int,
+            initValue: Float
+        ) = Array(batchSize) { Array(size) { FloatArray(channels) { initValue } } }
+
+        internal fun create1DTensor(
+            batchSize: Int,
+            channels: Int,
+            sequence: FloatArray,
+        ) = Array(batchSize) { Array(sequence.size) { idx -> FloatArray(channels) { sequence[idx] } } }
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -45,7 +45,7 @@ internal class Conv1DTest : ConvLayerTest() {
                 filters = 16,
                 kernelInitializer = Constant(1.0f),
                 biasInitializer = Zeros(),
-                kernelSize = 2,
+                kernelLength = 2,
                 padding = ConvPadding.VALID
             ),
             input,
@@ -70,7 +70,7 @@ internal class Conv1DTest : ConvLayerTest() {
                 filters = 1,
                 kernelInitializer = Constant(1.0f),
                 biasInitializer = Zeros(),
-                kernelSize = 3,
+                kernelLength = 3,
                 padding = ConvPadding.VALID
             ),
             input,

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTransposeTest.kt
@@ -106,7 +106,7 @@ class Conv1DTransposeTest : ConvLayerTest() {
     @Test
     fun samePaddingStrides() {
         val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
-        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 64f, 32f, 64f, 32f))
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f))
 
         assertTensorsEquals(
             Conv1DTranspose(

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv1DTransposeTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer
+
+import org.jetbrains.kotlinx.dl.api.core.initializer.Constant
+import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
+import org.jetbrains.kotlinx.dl.api.core.layer.Conv1DTest.Companion.create1DTensor
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import org.junit.jupiter.api.Test
+
+class Conv1DTransposeTest : ConvLayerTest() {
+    @Test
+    fun zeroInput() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 0f)
+        val expected = create1DTensor(batchSize = 1, size = 3, channels = 3, initValue = 0f)
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_zeroInput",
+                filters = 3,
+                biasInitializer = Zeros()
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPadding() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 64f, 96f, 64f, 32f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_noPadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePadding() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(64f, 96f, 64f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_samePadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun outputPadding() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 64f, 96f, 64f, 32f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_outputPadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                outputPadding = intArrayOf(0, 0, 1, 1, 0, 0)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPaddingStrides() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_noPadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID,
+                strides = intArrayOf(1, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePaddingStrides() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 64f, 32f, 64f, 32f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_samePadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                strides = intArrayOf(1, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun outputPaddingStrides() {
+        val input = create1DTensor(batchSize = 1, size = 3, channels = 32, initValue = 1f)
+        val expected = create1DTensor(batchSize = 1, channels = 3, floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f))
+
+        assertTensorsEquals(
+            Conv1DTranspose(
+                name = "TestConv1DTranspose_outputPadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                outputPadding = intArrayOf(0, 0, 1, 1, 0, 0),
+                strides = intArrayOf(1, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -12,18 +12,10 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.junit.jupiter.api.Test
 
 internal class Conv2DTest : ConvLayerTest() {
-    private fun createFloatConv2DTensor(
-        batchSize: Int,
-        height: Int,
-        width: Int,
-        channels: Int,
-        initValue: Float
-    ) = Array(batchSize) { Array(height) { Array(width) { FloatArray(channels) { initValue } } } }
-
     @Test
     fun zeroedInputTensorWithDefaultValues() {
-        val input = createFloatConv2DTensor(batchSize = 1, height = 3, width = 3, channels = 1, initValue = 0.0f)
-        val expected = createFloatConv2DTensor(batchSize = 1, height = 3, width = 3, channels = 32, initValue = 0.0f)
+        val input = create2DTensor(batchSize = 1, height = 3, width = 3, channels = 1, initValue = 0.0f)
+        val expected = create2DTensor(batchSize = 1, height = 3, width = 3, channels = 32, initValue = 0.0f)
 
         assertTensorsEquals(
             Conv2D(
@@ -37,8 +29,8 @@ internal class Conv2DTest : ConvLayerTest() {
 
     @Test
     fun constantInputTensorWithValidPadding() {
-        val input = createFloatConv2DTensor(batchSize = 1, height = 3, width = 3, channels = 1, initValue = 1.0f)
-        val expected = createFloatConv2DTensor(batchSize = 1, height = 2, width = 2, channels = 16, initValue = 4.0f)
+        val input = create2DTensor(batchSize = 1, height = 3, width = 3, channels = 1, initValue = 1.0f)
+        val expected = create2DTensor(batchSize = 1, height = 2, width = 2, channels = 16, initValue = 4.0f)
 
         assertTensorsEquals(
             Conv2D(
@@ -83,5 +75,25 @@ internal class Conv2DTest : ConvLayerTest() {
             input,
             expected
         )
+    }
+
+    internal companion object {
+        internal fun create2DTensor(
+            batchSize: Int,
+            height: Int,
+            width: Int,
+            channels: Int,
+            initValue: Float
+        ) = Array(batchSize) { Array(height) { Array(width) { FloatArray(channels) { initValue } } } }
+
+        internal fun create2DTensor(
+            batchSize: Int,
+            channels: Int,
+            vararg rows: FloatArray
+        ) = Array(batchSize) {
+            Array(rows.size) { rowIdx ->
+                Array(rows[rowIdx].size) { columnIdx -> FloatArray(channels) { rows[rowIdx][columnIdx] } }
+            }
+        }
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTransposeTest.kt
@@ -130,9 +130,10 @@ class Conv2DTransposeTest : ConvLayerTest() {
         val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
         val expected = create2DTensor(
             batchSize = 1, channels = 3,
-            floatArrayOf(32f, 64f, 32f, 64f, 32f),
-            floatArrayOf(64f, 128f, 64f, 128f, 64f),
-            floatArrayOf(32f, 64f, 32f, 64f, 32f)
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+            floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f)
         )
 
         assertTensorsEquals(

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv2DTransposeTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer
+
+import org.jetbrains.kotlinx.dl.api.core.initializer.Constant
+import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
+import org.jetbrains.kotlinx.dl.api.core.layer.Conv2DTest.Companion.create2DTensor
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import org.junit.jupiter.api.Test
+
+class Conv2DTransposeTest : ConvLayerTest() {
+    @Test
+    fun testZeroInput() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 0.0f)
+        val expected = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 3, initValue = 0.0f)
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_zeroInput",
+                biasInitializer = Zeros()
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPadding() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(32f, 64f, 96f, 64f, 32f),
+            floatArrayOf(64f, 128f, 192f, 128f, 64f),
+            floatArrayOf(64f, 128f, 192f, 128f, 64f),
+            floatArrayOf(32f, 64f, 96f, 64f, 32f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_noPadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePadding() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(128f, 192f, 128f),
+            floatArrayOf(128f, 192f, 128f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_samePadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun outputPadding() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(32f, 64f, 96f, 64f, 32f),
+            floatArrayOf(64f, 128f, 192f, 128f, 64f),
+            floatArrayOf(64f, 128f, 192f, 128f, 64f),
+            floatArrayOf(32f, 64f, 96f, 64f, 32f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_outputPadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                outputPadding = intArrayOf(0, 0, 1, 1, 1, 1, 0, 0)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPaddingStrides() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f, 64f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_noPadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID,
+                strides = intArrayOf(1, 2, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePaddingStrides() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(32f, 64f, 32f, 64f, 32f),
+            floatArrayOf(64f, 128f, 64f, 128f, 64f),
+            floatArrayOf(32f, 64f, 32f, 64f, 32f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_samePadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                strides = intArrayOf(1, 2, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun outputPaddingStrides() {
+        val input = create2DTensor(batchSize = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create2DTensor(
+            batchSize = 1, channels = 3,
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f, 64f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+            floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f)
+        )
+
+        assertTensorsEquals(
+            Conv2DTranspose(
+                name = "TestConv2DTranspose_outputPadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                outputPadding = intArrayOf(0, 0, 1, 1, 1, 1, 0, 0),
+                strides = intArrayOf(1, 2, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -12,21 +12,10 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
 import org.junit.jupiter.api.Test
 
 internal class Conv3DTest : ConvLayerTest() {
-    private fun createFloatConv3DTensor(
-        batchSize: Int,
-        depth: Int,
-        height: Int,
-        width: Int,
-        channels: Int,
-        initValue: Float
-    ) = Array(batchSize) { Array(depth) { Array(height) { Array(width) { FloatArray(channels) { initValue } } } } }
-
     @Test
     fun zeroedInputTensorWithDefaultValues() {
-        val input =
-            createFloatConv3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 1, initValue = 0.0f)
-        val expected =
-            createFloatConv3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 32, initValue = 0.0f)
+        val input = create3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 1, initValue = 0.0f)
+        val expected = create3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 32, initValue = 0.0f)
 
         assertTensorsEquals(
             Conv3D(
@@ -40,10 +29,8 @@ internal class Conv3DTest : ConvLayerTest() {
 
     @Test
     fun constantInputTensorWithValidPadding() {
-        val input =
-            createFloatConv3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 1, initValue = 1.0f)
-        val expected =
-            createFloatConv3DTensor(batchSize = 1, depth = 2, height = 2, width = 2, channels = 16, initValue = 8.0f)
+        val input = create3DTensor(batchSize = 1, depth = 3, height = 3, width = 3, channels = 1, initValue = 1.0f)
+        val expected = create3DTensor(batchSize = 1, depth = 2, height = 2, width = 2, channels = 16, initValue = 8.0f)
 
         assertTensorsEquals(
             Conv3D(
@@ -99,5 +86,29 @@ internal class Conv3DTest : ConvLayerTest() {
             input,
             expected
         )
+    }
+
+    internal companion object {
+        internal fun create3DTensor(
+            batchSize: Int,
+            depth: Int,
+            height: Int,
+            width: Int,
+            channels: Int,
+            initValue: Float
+        ) = Array(batchSize) { Array(depth) { Array(height) { Array(width) { FloatArray(channels) { initValue } } } } }
+
+        internal fun create3DTensor(
+            batchSize: Int,
+            channels: Int,
+            vararg frames: Array<FloatArray>
+        ) = Array(batchSize) {
+            Array(frames.size) { frameIdx ->
+                val rows = frames[frameIdx]
+                Array(rows.size) { rowIdx ->
+                    Array(rows[rowIdx].size) { columnIdx -> FloatArray(channels) { rows[rowIdx][columnIdx] } }
+                }
+            }
+        }
     }
 }

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTransposeTest.kt
@@ -138,9 +138,16 @@ class Conv3DTransposeTest : ConvLayerTest() {
         val expected = create3DTensor(
             batchSize = 1, channels = 3,
             arrayOf(
-                floatArrayOf(32f, 64f, 32f, 64f, 32f),
-                floatArrayOf(64f, 128f, 64f, 128f, 64f),
-                floatArrayOf(32f, 64f, 32f, 64f, 32f)
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+                floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+            ),
+            arrayOf(
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
+                floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f),
             )
         )
 

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTransposeTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/Conv3DTransposeTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.layer
+
+import org.jetbrains.kotlinx.dl.api.core.initializer.Constant
+import org.jetbrains.kotlinx.dl.api.core.initializer.Zeros
+import org.jetbrains.kotlinx.dl.api.core.layer.Conv3DTest.Companion.create3DTensor
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv3DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import org.junit.jupiter.api.Test
+
+class Conv3DTransposeTest : ConvLayerTest() {
+    @Test
+    fun testZeroInput() {
+        val input = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 32, initValue = 0.0f)
+        val expected = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 3, initValue = 0.0f)
+
+        assertTensorsEquals(
+            Conv3DTranspose(
+                name = "TestConv3DTranspose_zeroInput",
+                biasInitializer = Zeros()
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPadding() {
+        val input = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create3DTensor(
+            batchSize = 1, channels = 3,
+            arrayOf(
+                floatArrayOf(32f, 64f, 96f, 64f, 32f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(32f, 64f, 96f, 64f, 32f)
+            ),
+            arrayOf(
+                floatArrayOf(32f, 64f, 96f, 64f, 32f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(32f, 64f, 96f, 64f, 32f)
+            ),
+            arrayOf(
+                floatArrayOf(32f, 64f, 96f, 64f, 32f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(64f, 128f, 192f, 128f, 64f),
+                floatArrayOf(32f, 64f, 96f, 64f, 32f)
+            )
+        )
+
+        assertTensorsEquals(
+            Conv3DTranspose(
+                name = "TestConv3DTranspose_noPadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePadding() {
+        val input = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create3DTensor(
+            batchSize = 1, channels = 3,
+            arrayOf(
+                floatArrayOf(128f, 192f, 128f),
+                floatArrayOf(128f, 192f, 128f)
+            )
+        )
+
+        assertTensorsEquals(
+            Conv3DTranspose(
+                name = "TestConv3DTranspose_samePadding",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun noPaddingStrides() {
+        val input = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create3DTensor(
+            batchSize = 1, channels = 3,
+            arrayOf(
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f, 64f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f)
+            ),
+            arrayOf(
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f, 64f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f)
+            ),
+            arrayOf(
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(64f, 64f, 128f, 64f, 128f, 64f, 64f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f),
+                floatArrayOf(32f, 32f, 64f, 32f, 64f, 32f, 32f)
+            )
+        )
+
+        assertTensorsEquals(
+            Conv3DTranspose(
+                name = "TestConv3DTranspose_noPadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.VALID,
+                strides = intArrayOf(1, 2, 2, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+
+    @Test
+    fun samePaddingStrides() {
+        val input = create3DTensor(batchSize = 1, depth = 1, height = 2, width = 3, channels = 32, initValue = 1f)
+        val expected = create3DTensor(
+            batchSize = 1, channels = 3,
+            arrayOf(
+                floatArrayOf(32f, 64f, 32f, 64f, 32f),
+                floatArrayOf(64f, 128f, 64f, 128f, 64f),
+                floatArrayOf(32f, 64f, 32f, 64f, 32f)
+            )
+        )
+
+        assertTensorsEquals(
+            Conv3DTranspose(
+                name = "TestConv3DTranspose_samePadding_strides",
+                filters = 3,
+                kernelInitializer = Constant(1.0f),
+                biasInitializer = Zeros(),
+                padding = ConvPadding.SAME,
+                strides = intArrayOf(1, 2, 2, 2, 1)
+            ),
+            input,
+            expected
+        )
+    }
+}

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/ConvLayerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -32,6 +32,7 @@ open class ConvLayerTest {
                     val numberOfLosses = tf.constant(1.0f)
 
                     layer.build(tf, kGraph, input.shape)
+                    layer.computeOutputShape(input.shape)
                     val output = layer.forward(tf, inputOp, isTraining, numberOfLosses).asOutput()
                     kGraph.initializeGraphVariables(session)
                     session.runner().fetch(output).run().first().use { outputTensor ->

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ConvTransposePersistenceTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/ConvTransposePersistenceTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.GraphTrainableModel
+import org.jetbrains.kotlinx.dl.api.core.Sequential
+import org.jetbrains.kotlinx.dl.api.core.activation.Activations
+import org.jetbrains.kotlinx.dl.api.core.initializer.HeUniform
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv1DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv3DTranspose
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvPadding
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Input
+import org.jetbrains.kotlinx.dl.api.core.loss.Losses
+import org.jetbrains.kotlinx.dl.api.core.metric.Metrics
+import org.jetbrains.kotlinx.dl.api.core.optimizer.Adam
+import org.jetbrains.kotlinx.dl.api.core.regularizer.L2
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class ConvTransposePersistenceTest {
+    private lateinit var tempFile: File
+
+    @BeforeEach
+    fun createTempFile() {
+        tempFile = File.createTempFile("model", ".json")
+    }
+
+    @AfterEach
+    fun deleteTempFile() {
+        tempFile.delete()
+    }
+
+    @Test
+    fun conv1DTranspose() {
+        testSequentialModel(
+            Sequential.of(
+                Input(dims = longArrayOf(3)),
+                Conv1DTranspose(
+                    filters = 5,
+                    kernelLength = 5,
+                    strides = intArrayOf(1, 2, 1),
+                    activation = Activations.Tanh,
+                    dilations = intArrayOf(1, 2, 1),
+                    kernelInitializer = HeUniform(),
+                    biasInitializer = HeUniform(),
+                    kernelRegularizer = L2(),
+                    biasRegularizer = L2(),
+                    activityRegularizer = L2(),
+                    padding = ConvPadding.VALID,
+                    outputPadding = intArrayOf(0, 0, 1, 1, 0, 0)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun conv2DTranspose() {
+        testSequentialModel(
+            Sequential.of(
+                Input(dims = longArrayOf(3, 3)),
+                Conv2DTranspose(
+                    filters = 5,
+                    kernelSize = intArrayOf(5, 5),
+                    strides = intArrayOf(1, 2, 4, 1),
+                    activation = Activations.Tanh,
+                    dilations = intArrayOf(1, 2, 4, 1),
+                    kernelInitializer = HeUniform(),
+                    biasInitializer = HeUniform(),
+                    kernelRegularizer = L2(),
+                    biasRegularizer = L2(),
+                    activityRegularizer = L2(),
+                    padding = ConvPadding.VALID,
+                    outputPadding = intArrayOf(0, 0, 1, 1, 2, 2, 0, 0)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun conv3DTranspose() {
+        testSequentialModel(
+            Sequential.of(
+                Input(dims = longArrayOf(3, 3, 3)),
+                Conv3DTranspose(
+                    filters = 5,
+                    kernelSize = intArrayOf(5, 5, 5),
+                    strides = intArrayOf(1, 2, 4, 2, 1),
+                    activation = Activations.Tanh,
+                    dilations = intArrayOf(1, 2, 4, 2, 1),
+                    kernelInitializer = HeUniform(),
+                    biasInitializer = HeUniform(),
+                    kernelRegularizer = L2(),
+                    biasRegularizer = L2(),
+                    activityRegularizer = L2(),
+                    padding = ConvPadding.VALID,
+                )
+            )
+        )
+    }
+
+    private fun testSequentialModel(originalModel: Sequential) {
+        originalModel.saveModelConfiguration(tempFile)
+        val restoredModel = Sequential.loadModelConfiguration(tempFile)
+        assertSameModel(originalModel, restoredModel)
+    }
+
+    private fun assertSameModel(expectedModel: GraphTrainableModel, actualModel: GraphTrainableModel) {
+        listOf(expectedModel, actualModel).forEach {
+            it.compile(Adam(), Losses.MSE, Metrics.ACCURACY)
+        }
+        Assertions.assertEquals(expectedModel.layers.joinToString("\n") { it.toString() },
+                                actualModel.layers.joinToString("\n") { it.toString() })
+    }
+}

--- a/examples/src/main/kotlin/examples/cnn/fsdd/SoundNet.kt
+++ b/examples/src/main/kotlin/examples/cnn/fsdd/SoundNet.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2021-2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -41,7 +41,7 @@ internal fun soundBlock(filters: Int, kernelSize: Int, poolStride: Int): Array<L
     arrayOf(
         Conv1D(
             filters = filters,
-            kernelSize = kernelSize,
+            kernelLength = kernelSize,
             strides = intArrayOf(1, 1, 1),
             activation = Activations.Relu,
             kernelInitializer = HeNormal(SEED),
@@ -50,7 +50,7 @@ internal fun soundBlock(filters: Int, kernelSize: Int, poolStride: Int): Array<L
         ),
         Conv1D(
             filters = filters,
-            kernelSize = kernelSize,
+            kernelLength = kernelSize,
             strides = intArrayOf(1, 1, 1),
             activation = Activations.Relu,
             kernelInitializer = HeNormal(SEED),


### PR DESCRIPTION
This PR adds implementations for `Conv1DTranspose`, `Conv2DTranspose` and `Conv3DTranspose` layers.

Caveats:
1. Dilation values greater than 1 are not supported in tensorflow on cpu: https://github.com/tensorflow/tensorflow/issues/28264. Therefore, I have not added any tests for dilations as they do not work.
2. Output padding is not supported in `org.tensorflow.op.NnOps#conv3dBackpropInput`. `Conv3DTranspose` still has the parameter, it just does not do anything. I'm not sure if this parameter is needed or if it is, where to add a warning about its usage.

Fixes #124