### PR TITLE
Simplify loading layer weights support for new layers

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightLoader.kt
@@ -144,7 +144,10 @@ private fun fillLayerWeights(
     model: GraphTrainableModel
 ) {
     val variables = getLayerVariables(layer)
-    if (variables == null) return
+    if (variables == null) {
+        model.logger.warn { "Loading weights for the layer ${layer.name} is skipped as ${layer::class.qualifiedName} layers are not supported." }
+        return
+    }
     fillLayerVariablesFromKeras(layer.name, variables, model, group)
     model.logger.debug { "${layer.paramCount} parameters loaded for the layer ${layer.name}." }
 }
@@ -314,7 +317,10 @@ private fun fillLayerWeights(
         is BatchNorm -> getBatchNormVariables(layer, layerPaths)
         else -> null
     }
-    if (variables == null) return
+    if (variables == null) {
+        model.logger.warn { "Loading weights for the layer ${layer.name} is skipped as ${layer::class.qualifiedName} layers are not supported." }
+        return
+    }
     variables.forEach { (variableName, variableDataPathTemplate) ->
         val data = hdfFile.getDatasetByPath(variableDataPathTemplate.format(layer.name, layer.name)).data
         model.fillVariable(variableName, data)
@@ -324,7 +330,10 @@ private fun fillLayerWeights(
 
 private fun initLayerWeights(layer: Layer, model: GraphTrainableModel) {
     val variables = getLayerVariableNames(layer)
-    if (variables == null) return
+    if (variables == null) {
+        model.logger.warn { "Initializing weights for the layer ${layer.name} is skipped as ${layer::class.qualifiedName} layers are not supported." }
+        return
+    }
     variables.forEach(model::runAssignOpByVarName)
     model.logger.debug { "${layer.paramCount} parameters initialized for the layer ${layer.name}." }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightLoader.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightLoader.kt
@@ -188,42 +188,58 @@ private fun fillLayerVariablesFromKeras(layerName: String,
 }
 
 private fun getConv2DVariables(layer: Conv2D): Map<String, Pair<String, LongArray>> {
-    return mapOf(
-        Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernelShapeArray)),
-        Pair("bias:0", Pair(convBiasVarName(layer.name, dim = 2), layer.biasShapeArray!!))
+    val variables = mutableMapOf(
+        Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernelShapeArray))
     )
+    if (layer.useBias) {
+        variables["bias:0"] = Pair(convBiasVarName(layer.name, dim = 2), layer.biasShapeArray!!)
+    }
+    return variables
 }
 
 private fun getDepthwiseConv2DVariables(layer: DepthwiseConv2D): Map<String, Pair<String, LongArray>> {
-    return mapOf(
-        Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernelShapeArray)),
-        Pair("depthwise_bias:0", Pair(depthwiseConv2dBiasVarName(layer.name), layer.biasShapeArray!!))
+    val variables = mutableMapOf(
+        Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernelShapeArray))
     )
+    if (layer.useBias) {
+        variables["depthwise_bias:0"] = Pair(depthwiseConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+    }
+    return variables
 }
 
 private fun getSeparableConv2DVariables(layer: SeparableConv2D): Map<String, Pair<String, LongArray>> {
-    return mapOf(
+    val variables = mutableMapOf(
         Pair("depthwise_kernel:0", Pair(separableConv2dDepthwiseKernelVarName(layer.name), layer.depthwiseShapeArray)),
-        Pair("pointwise_kernel:0", Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseShapeArray)),
-        Pair("depthwise_bias:0", Pair(separableConv2dBiasVarName(layer.name), layer.biasShapeArray!!))
+        Pair("pointwise_kernel:0", Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseShapeArray))
     )
+    if (layer.useBias) {
+        variables["bias:0"] = Pair(separableConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+    }
+    return variables
 }
 
 private fun getDenseVariables(layer: Dense): Map<String, Pair<String, LongArray>> {
-    return mapOf(
-        Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernelShapeArray)),
-        Pair("bias:0", Pair(denseBiasVarName(layer.name), layer.biasShapeArray!!))
+    val variables = mutableMapOf(
+        Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernelShapeArray))
     )
+    if (layer.useBias) {
+        variables["bias:0"] = Pair(denseBiasVarName(layer.name), layer.biasShapeArray!!)
+    }
+    return variables
 }
 
-// TODO: gamma and beta could be misssed due to batchNorm formula https://stackoverflow.com/questions/43813549/restoring-tensorflow-model-cannot-find-gamma-scale-for-batch-norm-layers-in-the
 private fun getBatchNormVariables(layer: BatchNorm): Map<String, Pair<String, LongArray>> {
-    return mapOf(
-        Pair("gamma:0", Pair(batchNormGammaVarName(layer.name), layer.gammaShapeArray!!)),
-        Pair("beta:0", Pair(batchNormBetaVarName(layer.name), layer.betaShapeArray!!)),
+    val variables = mutableMapOf(
         Pair("moving_mean:0", Pair(batchNormMovingMeanVarName(layer.name), layer.movingMeanShapeArray)),
         Pair("moving_variance:0", Pair(batchNormMovingVarianceVarName(layer.name), layer.movingVarianceShapeArray))
     )
+    if (layer.scale) {
+        variables["gamma:0"] = Pair(batchNormGammaVarName(layer.name), layer.gammaShapeArray!!)
+    }
+    if (layer.center) {
+        variables["beta:0"] = Pair(batchNormBetaVarName(layer.name), layer.betaShapeArray!!)
+    }
+    return variables
 }
 
 /**

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.inference.keras
+
+import org.jetbrains.kotlinx.dl.api.core.layer.Layer
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2D
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
+import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.SeparableConv2D
+import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
+import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
+import org.jetbrains.kotlinx.dl.api.core.util.*
+
+internal object WeightMappings {
+
+    internal const val KERNEL_DATA_PATH_TEMPLATE = "/%s/%s/kernel:0"
+    internal const val BIAS_DATA_PATH_TEMPLATE = "/%s/%s/bias:0"
+    private const val GAMMA_DATA_PATH_TEMPLATE = "/%s/%s/gamma:0"
+    private const val BETA_DATA_PATH_TEMPLATE = "/%s/%s/beta:0"
+    private const val MOVING_MEAN_DATA_PATH_TEMPLATE = "/%s/%s/moving_mean:0"
+    private const val MOVING_VARIANCE_DATA_PATH_TEMPLATE = "/%s/%s/moving_variance:0"
+    private const val DEPTHWISE_KERNEL_DATA_PATH_TEMPLATE = "/%s/%s/depthwise_kernel:0"
+    private const val POINTWISE_KERNEL_DATA_PATH_TEMPLATE = "/%s/%s/pointwise_kernel:0"
+    private const val DEPTHWISE_BIAS_DATA_PATH_TEMPLATE = "/%s/%s/depthwise_bias:0"
+
+    // TODO: add loading for all layers with weights from Keras like Conv1D and Conv3D
+    internal fun getLayerVariables(layer: Layer): Map<String, Pair<String, LongArray>>? {
+        return when (layer) {
+            is Dense -> getDenseVariables(layer)
+            is Conv2D -> getConv2DVariables(layer)
+            is DepthwiseConv2D -> getDepthwiseConv2DVariables(layer)
+            is SeparableConv2D -> getSeparableConv2DVariables(layer)
+            is BatchNorm -> getBatchNormVariables(layer)
+            else -> null
+        }
+    }
+
+    internal fun getLayerVariableNames(layer: Layer): List<String>? {
+        return getLayerVariables(layer)?.map { (_, variable) -> variable.first }
+    }
+
+    internal fun getLayerVariablePathTemplates(layer: Layer, layerPaths: LayerPaths?): Map<String, String>? {
+        return when (layer) {
+            is Dense -> getDenseVariablesPathTemplates(layer, layerPaths)
+            is Conv2D -> getConv2DVariablePathTemplates(layer, layerPaths)
+            is DepthwiseConv2D -> getDepthwiseConv2DVariablePathTemplates(layer, layerPaths)
+            is SeparableConv2D -> getSeparableConv2DVariablePathTemplates(layer, layerPaths)
+            is BatchNorm -> getBatchNormVariablePathTemplates(layer, layerPaths)
+            else -> null
+        }
+    }
+
+    private fun getConv2DVariables(layer: Conv2D): Map<String, Pair<String, LongArray>> {
+        val variables = mutableMapOf(
+            Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernelShapeArray))
+        )
+        if (layer.useBias) {
+            variables["bias:0"] = Pair(convBiasVarName(layer.name, dim = 2), layer.biasShapeArray!!)
+        }
+        return variables
+    }
+
+    private fun getConv2DVariablePathTemplates(layer: Conv2D, layerPaths: LayerPaths?): Map<String, String> {
+        val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
+            ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
+        val variables = mutableMapOf(
+            Pair(convKernelVarName(layer.name, dim = 2), layerConvOrDensePaths.kernelPath)
+        )
+        if (layer.useBias) {
+            variables[convBiasVarName(layer.name, dim = 2)] = layerConvOrDensePaths.biasPath
+        }
+        return variables
+    }
+
+    private fun getDepthwiseConv2DVariables(layer: DepthwiseConv2D): Map<String, Pair<String, LongArray>> {
+        val variables = mutableMapOf(
+            Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernelShapeArray))
+        )
+        if (layer.useBias) {
+            variables["depthwise_bias:0"] = Pair(depthwiseConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+        }
+        return variables
+    }
+
+    private fun getDepthwiseConv2DVariablePathTemplates(layer: DepthwiseConv2D,
+                                                        layerPaths: LayerPaths?
+    ): Map<String, String> {
+        val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
+            ?: LayerConvOrDensePaths(
+                layer.name,
+                DEPTHWISE_KERNEL_DATA_PATH_TEMPLATE,
+                DEPTHWISE_BIAS_DATA_PATH_TEMPLATE
+            )
+        val variables = mutableMapOf(
+            Pair(depthwiseConv2dKernelVarName(layer.name), layerConvOrDensePaths.kernelPath)
+        )
+        if (layer.useBias) {
+            variables[depthwiseConv2dBiasVarName(layer.name)] = layerConvOrDensePaths.biasPath
+        }
+        return variables
+    }
+
+    private fun getSeparableConv2DVariables(layer: SeparableConv2D): Map<String, Pair<String, LongArray>> {
+        val variables = mutableMapOf(
+            Pair(
+                "depthwise_kernel:0",
+                Pair(separableConv2dDepthwiseKernelVarName(layer.name), layer.depthwiseShapeArray)
+            ),
+            Pair(
+                "pointwise_kernel:0",
+                Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseShapeArray)
+            )
+        )
+        if (layer.useBias) {
+            variables["bias:0"] = Pair(separableConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+        }
+        return variables
+    }
+
+    private fun getSeparableConv2DVariablePathTemplates(layer: SeparableConv2D,
+                                                        layerPaths: LayerPaths?
+    ): Map<String, String> {
+        val layerSeparableConv2DPaths = layerPaths as? LayerSeparableConv2DPaths
+            ?: LayerSeparableConv2DPaths(
+                layer.name,
+                DEPTHWISE_KERNEL_DATA_PATH_TEMPLATE,
+                POINTWISE_KERNEL_DATA_PATH_TEMPLATE,
+                DEPTHWISE_BIAS_DATA_PATH_TEMPLATE
+            )
+        val variables = mutableMapOf(
+            Pair(separableConv2dDepthwiseKernelVarName(layer.name), layerSeparableConv2DPaths.depthwiseKernelPath),
+            Pair(separableConv2dPointwiseKernelVarName(layer.name), layerSeparableConv2DPaths.pointwiseKernelPath)
+        )
+        if (layer.useBias) {
+            variables[separableConv2dBiasVarName(layer.name)] = layerSeparableConv2DPaths.biasPath
+        }
+        return variables
+    }
+
+    private fun getDenseVariables(layer: Dense): Map<String, Pair<String, LongArray>> {
+        val variables = mutableMapOf(
+            Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernelShapeArray))
+        )
+        if (layer.useBias) {
+            variables["bias:0"] = Pair(denseBiasVarName(layer.name), layer.biasShapeArray!!)
+        }
+        return variables
+    }
+
+    private fun getDenseVariablesPathTemplates(layer: Dense, layerPaths: LayerPaths?): Map<String, String> {
+        val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
+            ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
+        val variables = mutableMapOf(
+            Pair(denseKernelVarName(layer.name), layerConvOrDensePaths.kernelPath)
+        )
+        if (layer.useBias) {
+            variables[denseBiasVarName(layer.name)] = layerConvOrDensePaths.biasPath
+        }
+        return variables
+    }
+
+    private fun getBatchNormVariables(layer: BatchNorm): Map<String, Pair<String, LongArray>> {
+        val variables = mutableMapOf(
+            Pair("moving_mean:0", Pair(batchNormMovingMeanVarName(layer.name), layer.movingMeanShapeArray)),
+            Pair("moving_variance:0", Pair(batchNormMovingVarianceVarName(layer.name), layer.movingVarianceShapeArray))
+        )
+        if (layer.scale) {
+            variables["gamma:0"] = Pair(batchNormGammaVarName(layer.name), layer.gammaShapeArray!!)
+        }
+        if (layer.center) {
+            variables["beta:0"] = Pair(batchNormBetaVarName(layer.name), layer.betaShapeArray!!)
+        }
+        return variables
+    }
+
+
+    private fun getBatchNormVariablePathTemplates(layer: BatchNorm, layerPaths: LayerPaths?): Map<String, String> {
+        val layerBatchNormPaths = layerPaths as? LayerBatchNormPaths
+            ?: LayerBatchNormPaths(
+                layer.name,
+                GAMMA_DATA_PATH_TEMPLATE,
+                BETA_DATA_PATH_TEMPLATE,
+                MOVING_MEAN_DATA_PATH_TEMPLATE,
+                MOVING_VARIANCE_DATA_PATH_TEMPLATE
+            )
+        val variables = mutableMapOf(
+            Pair(batchNormMovingMeanVarName(layer.name), layerBatchNormPaths.movingMeanPath),
+            Pair(batchNormMovingVarianceVarName(layer.name), layerBatchNormPaths.movingVariancePath)
+        )
+        if (layer.scale) {
+            variables[batchNormGammaVarName(layer.name)] = layerBatchNormPaths.gammaPath
+        }
+        if (layer.center) {
+            variables[batchNormBetaVarName(layer.name)] = layerBatchNormPaths.betaPath
+        }
+        return variables
+    }
+}
+
+/**
+ * Parent class for specific paths to layers in h5 file. Contains only [layerName] field */
+public open class LayerPaths(
+    /** */
+    public val layerName: String
+)
+
+/**
+ * Contains [layerName], [kernelPath], [biasPath] for specific layer, found in hdf5 file via
+ * ```
+ * recursivePrintGroupInHDF5File()
+ * ```
+ * function call.
+ */
+public class LayerConvOrDensePaths(
+    layerName: String,
+    /** */
+    public val kernelPath: String,
+    /** */
+    public val biasPath: String
+) : LayerPaths(layerName)
+
+/**
+ * Contains [layerName], [depthwiseKernelPath],  [pointwiseKernelPath], [biasPath] for [SeparableConv2D] layer, found in hdf5 file via
+ * ```
+ * recursivePrintGroupInHDF5File()
+ * ```
+ * function call.
+ */
+public class LayerSeparableConv2DPaths(
+    layerName: String,
+    /** */
+    public val depthwiseKernelPath: String,
+    /** */
+    public val pointwiseKernelPath: String,
+    /** */
+    public val biasPath: String
+) : LayerPaths(layerName)
+
+/**
+ * Contains [layerName], [gammaPath],  [betaPath], [movingMeanPath], [movingVariancePath] for [BatchNorm] layer, found in hdf5 file via
+ * ```
+ * recursivePrintGroupInHDF5File()
+ * ```
+ * function call.
+ */
+public class LayerBatchNormPaths(
+    layerName: String,
+    /** */
+    public val gammaPath: String,
+    /** */
+    public val betaPath: String,
+    /** */
+    public val movingMeanPath: String,
+    /** */
+    public val movingVariancePath: String
+) : LayerPaths(layerName)

--- a/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TransferLearningFromKerasTest.kt
+++ b/api/src/test/kotlin/org/jetbrains/kotlinx/dl/api/core/integration/TransferLearningFromKerasTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Copyright 2020-2021 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -107,7 +107,7 @@ class TransferLearningTest : IntegrationTest() {
                 model.loadWeights(modelDirectory)
             }
         assertEquals(
-            "Weights for the loaded Conv2D layer conv2d_12 are not found in .h5 file! \n" +
+            "Weights for the loaded layer conv2d_12 are not found in .h5 file! \n" +
                     "h5 weight file contains weights for the following list of layers: [conv2d, conv2d_1, dense, dense_1, dense_2, flatten, max_pooling2d, max_pooling2d_1]\n" +
                     "Double-check your loaded configuration which contains layers with the following names: [input, conv2d_12, max_pooling2d_96, conv2d_1, max_pooling2d_1, flatten, dense, dense_1, dense_2].",
             exception.message


### PR DESCRIPTION
The goal of this PR is to make adding support for the new layers to the `WeightLoader` a little bit easier and help with finishing https://github.com/JetBrains/KotlinDL/pull/315.
The code for specific layer classes is extracted into `WeightMappings` file. For each layer there are two methods: `get<LAYER_NAME>Variables` and `get<LAYER_NAME>VariablePathTemplates` which provide information about layer variables and how to read them. In the future, after https://github.com/JetBrains/KotlinDL/pull/277 is merged, these methods will use `KVariable` and become even simpler.
This PR also adds warnings when a layer in the model is not yet supported.