### PR TITLE
Use KVariable in weight mappings

### DIFF
--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/AbstractConv.kt
@@ -62,10 +62,10 @@ public abstract class AbstractConv(
     internal abstract val useBias: Boolean
 
     /** Tensor with kernel weights */
-    protected lateinit var kernel: KVariable
+    internal lateinit var kernel: KVariable
 
     /** Tensor with bias weights */
-    protected var bias: KVariable? = null
+    internal var bias: KVariable? = null
 
     override fun build(tf: Ops, kGraph: KGraph, inputShape: Shape) {
         // Amount of channels should be the last value in the inputShape
@@ -122,12 +122,6 @@ public abstract class AbstractConv(
 
         return Activations.convert(activation).apply(tf, withBias, name)
     }
-
-    /** Returns the shape of kernel weights. */
-    public val kernelShapeArray: LongArray? get() = if (this::kernel.isInitialized)  TensorShape(kernel.shape).dims() else null
-
-    /** Returns the shape of bias weights. */
-    public val biasShapeArray: LongArray? get() = bias?.let { TensorShape(it.shape).dims() }
 
     override var weights: Map<String, Array<*>>
         get() = extractWeights(kernel, bias)

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv1D.kt
@@ -140,7 +140,13 @@ public class Conv1D(
     }
 
     override fun toString(): String {
-        return "Conv1D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, activation=$activation, kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, padding=$padding, useBias=$useBias, hasActivation=$hasActivation, kernelShapeArray=${kernelShapeArray?.contentToString()}, biasShapeArray=${biasShapeArray?.contentToString()})"
+        return "Conv1D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, " +
+                "strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, " +
+                "kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, " +
+                "padding=$padding, useBias=$useBias, hasActivation=$hasActivation, " +
+                "kernelShapeArray=${kernel.shape}, biasShapeArray=${bias?.shape})"
     }
 
     internal companion object {

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv2D.kt
@@ -144,6 +144,12 @@ public class Conv2D(
     override fun biasVarName(name: String): String = convBiasVarName(name, dim = 2)
 
     override fun toString(): String {
-        return "Conv2D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, activation=$activation, kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, padding=$padding, useBias=$useBias, hasActivation=$hasActivation, kernelShapeArray=${kernelShapeArray?.contentToString()}, biasShapeArray=${biasShapeArray?.contentToString()})"
+        return "Conv2D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, " +
+                "strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, " +
+                "kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, " +
+                "padding=$padding, useBias=$useBias, hasActivation=$hasActivation, " +
+                "kernelShapeArray=${kernel.shape}, biasShapeArray=${bias?.shape})"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/Conv3D.kt
@@ -157,6 +157,13 @@ public class Conv3D(
     }
 
     override fun toString(): String {
-        return "Conv3D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, activation=$activation, kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, padding=$padding, useBias=$useBias, hasActivation=$hasActivation, kernelShapeArray=${kernelShapeArray?.contentToString()}, biasShapeArray=${biasShapeArray?.contentToString()})"
+        return "Conv3D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, " +
+                "strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, " +
+                "activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, " +
+                "kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, " +
+                "activityRegularizer=$activityRegularizer, padding=$padding, " +
+                "useBias=$useBias, hasActivation=$hasActivation, " +
+                "kernelShapeArray=${kernel.shape}, biasShapeArray=${bias?.shape})"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/DepthwiseConv2D.kt
@@ -168,7 +168,7 @@ public class DepthwiseConv2D(
                 "padding=$padding, " +
                 "useBias=$useBias, " +
                 "hasActivation=$hasActivation, " +
-                "depthwiseKernelShapeArray=${kernelShapeArray?.contentToString()}, " +
-                "biasShapeArray=${biasShapeArray?.contentToString()})"
+                "depthwiseKernelShapeArray=${kernel.shape}, " +
+                "biasShapeArray=${bias?.shape})"
     }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/convolutional/SeparableConv2D.kt
@@ -114,9 +114,9 @@ public class SeparableConv2D(
     )
 
     // weight tensors
-    private lateinit var depthwiseKernel: KVariable
-    private lateinit var pointwiseKernel: KVariable
-    private var bias: KVariable? = null
+    internal lateinit var depthwiseKernel: KVariable
+    internal lateinit var pointwiseKernel: KVariable
+    internal var bias: KVariable? = null
 
     init {
         requireArraySize(kernelSize, 2, "kernelSize")
@@ -225,21 +225,19 @@ public class SeparableConv2D(
     }
 
     override fun toString(): String {
-        return "SeparableConv2D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, activation=$activation, depthMultiplier=$depthMultiplier, depthwiseInitializer=$depthwiseInitializer, pointwiseInitializer=$pointwiseInitializer, biasInitializer=$biasInitializer, depthwiseRegularizer=$depthwiseRegularizer, pointwiseRegularizer=$pointwiseRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, padding=$padding, useBias=$useBias, depthwiseShapeArray=${depthwiseShapeArray.contentToString()}, pointwiseShapeArray=${pointwiseShapeArray.contentToString()}, biasShapeArray=${biasShapeArray?.contentToString()}, hasActivation=$hasActivation)"
+        return "SeparableConv2D(name = $name, isTrainable=$isTrainable, filters=$filters, kernelSize=${kernelSize.contentToString()}, " +
+                "strides=${strides.contentToString()}, dilations=${dilations.contentToString()}, activation=$activation, " +
+                "depthMultiplier=$depthMultiplier, " +
+                "depthwiseInitializer=$depthwiseInitializer, pointwiseInitializer=$pointwiseInitializer, biasInitializer=$biasInitializer, " +
+                "depthwiseRegularizer=$depthwiseRegularizer, pointwiseRegularizer=$pointwiseRegularizer, biasRegularizer=$biasRegularizer, " +
+                "activityRegularizer=$activityRegularizer, padding=$padding, useBias=$useBias, " +
+                "depthwiseShapeArray=${depthwiseKernel.shape}, pointwiseShapeArray=${pointwiseKernel.shape}, biasShapeArray=${bias?.shape}, " +
+                "hasActivation=$hasActivation)"
     }
 
     override var weights: Map<String, Array<*>>
         get() = extractWeights(depthwiseKernel, pointwiseKernel, bias)
         set(value) = assignWeights(value)
-
-    /** Returns the shape of kernel weights. */
-    public val depthwiseShapeArray: LongArray? get() = if (this::depthwiseKernel.isInitialized) TensorShape(depthwiseKernel.shape).dims() else null
-
-    /** Returns the shape of kernel weights. */
-    public val pointwiseShapeArray: LongArray? get() = if (this::pointwiseKernel.isInitialized) TensorShape(pointwiseKernel.shape).dims() else null
-
-    /** Returns the shape of bias weights. */
-    public val biasShapeArray: LongArray? get() = bias?.let { TensorShape(it.shape).dims() }
 
     override val hasActivation: Boolean get() = true
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/core/Dense.kt
@@ -55,8 +55,8 @@ public class Dense(
     public val useBias: Boolean = true,
     name: String = ""
 ) : Layer(name) {
-    private lateinit var kernel: KVariable
-    private var bias: KVariable? = null
+    internal lateinit var kernel: KVariable
+    internal var bias: KVariable? = null
 
     override fun build(tf: Ops, kGraph: KGraph, inputShape: Shape) {
         val fanIn = inputShape.size(inputShape.numDimensions() - 1).toInt()
@@ -107,7 +107,10 @@ public class Dense(
     }
 
     override fun toString(): String {
-        return "Dense(name = $name, isTrainable=$isTrainable, outputSize=$outputSize, activation=$activation, kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, useBias=$useBias, hasActivation=$hasActivation, kernelShapeArray=${kernelShapeArray?.contentToString()}, biasShapeArray=${biasShapeArray?.contentToString()})"
+        return "Dense(name = $name, isTrainable=$isTrainable, outputSize=$outputSize, activation=$activation, " +
+                "kernelInitializer=$kernelInitializer, biasInitializer=$biasInitializer, " +
+                "kernelRegularizer=$kernelRegularizer, biasRegularizer=$biasRegularizer, activityRegularizer=$activityRegularizer, " +
+                "useBias=$useBias, hasActivation=$hasActivation, kernelShapeArray=${kernel.shape}, biasShapeArray=${bias?.shape})"
     }
 
     override var weights: Map<String, Array<*>>
@@ -118,10 +121,4 @@ public class Dense(
 
     override val paramCount: Int
         get() = listOfNotNull(kernel, bias).sumOf { it.shape.numElements() }.toInt()
-
-    /** Returns the shape of kernel weights. */
-    public val kernelShapeArray: LongArray? get() = if (this::kernel.isInitialized) TensorShape(kernel.shape).dims() else null
-
-    /** Returns the shape of bias weights. */
-    public val biasShapeArray: LongArray? get() = bias?.let { TensorShape(it.shape).dims() }
 }

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/layer/normalization/BatchNorm.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.NoGradients
 import org.jetbrains.kotlinx.dl.api.core.layer.createVariable
 import org.jetbrains.kotlinx.dl.api.core.regularizer.Regularizer
-import org.jetbrains.kotlinx.dl.api.core.shape.TensorShape
 import org.jetbrains.kotlinx.dl.api.core.shape.numElements
 import org.jetbrains.kotlinx.dl.api.core.util.batchNormBetaVarName
 import org.jetbrains.kotlinx.dl.api.core.util.batchNormGammaVarName
@@ -58,10 +57,10 @@ public class BatchNorm(
     public val movingVarianceInitializer: Initializer = Ones(),
     name: String = "",
 ) : Layer(name), NoGradients {
-    private var gamma: KVariable? = null
-    private var beta: KVariable? = null
-    private lateinit var movingMean: KVariable
-    private lateinit var movingVariance: KVariable
+    internal var gamma: KVariable? = null
+    internal var beta: KVariable? = null
+    internal lateinit var movingMean: KVariable
+    internal lateinit var movingVariance: KVariable
 
     init {
         isTrainable = false
@@ -183,7 +182,13 @@ public class BatchNorm(
     }
 
     override fun toString(): String {
-        return "BatchNorm(name = $name, isTrainable=$isTrainable, axis=$axis, momentum=$momentum, center=$center, epsilon=$epsilon, scale=$scale, gammaInitializer=$gammaInitializer, betaInitializer=$betaInitializer, gammaRegularizer=$gammaRegularizer, betaRegularizer=$betaRegularizer, movingMeanInitializer=$movingMeanInitializer, movingVarianceInitializer=$movingVarianceInitializer, hasActivation=$hasActivation, gammaShapeArray=${gammaShapeArray?.contentToString()}, betaShapeArray=${betaShapeArray?.contentToString()}, movingMeanShapeArray=${movingMeanShapeArray.contentToString()}, movingVarianceShapeArray=${movingVarianceShapeArray.contentToString()})"
+        return "BatchNorm(name = $name, isTrainable=$isTrainable, axis=$axis, momentum=$momentum, center=$center, epsilon=$epsilon, scale=$scale, " +
+                "gammaInitializer=$gammaInitializer, betaInitializer=$betaInitializer, " +
+                "gammaRegularizer=$gammaRegularizer, betaRegularizer=$betaRegularizer, " +
+                "movingMeanInitializer=$movingMeanInitializer, movingVarianceInitializer=$movingVarianceInitializer, " +
+                "hasActivation=$hasActivation, " +
+                "gammaShapeArray=${gamma?.shape}, betaShapeArray=${beta?.shape}, " +
+                "movingMeanShapeArray=${movingMean.shape}, movingVarianceShapeArray=${movingVariance.shape})"
     }
 
     override var weights: Map<String, Array<*>>
@@ -194,24 +199,5 @@ public class BatchNorm(
 
     override val paramCount: Int
         get() = listOfNotNull(gamma, beta, movingMean, movingVariance).sumOf { it.shape.numElements() }.toInt()
-
-
-    /** Returns the shape of gamma variable weights. */
-    public val gammaShapeArray: LongArray?
-        get() = gamma?.let { TensorShape(it.shape).dims() }
-
-    /** Returns the shape of beta variable weights. */
-    public val betaShapeArray: LongArray?
-        get() = beta?.let { TensorShape(it.shape).dims() }
-
-    /** Returns the shape of movingMean variable weights. */
-    public val movingMeanShapeArray: LongArray?
-        get() = if (this::movingMean.isInitialized) TensorShape(movingMean.shape).dims() else null
-
-    /** Returns the shape of movingVariance variable weights. */
-    public val movingVarianceShapeArray: LongArray?
-        get() = if (this::movingVariance.isInitialized) TensorShape(movingVariance.shape).dims() else null
-
-
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/ContainerUtil.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/core/util/ContainerUtil.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 JetBrains s.r.o. and Kotlin Deep Learning project contributors. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlinx.dl.api.core.util
+
+/**
+ * Create a new read-only map from a list of pairs, if both values in the pair are not null.
+ *
+ * @param [mapping] pairs of keys and values to put into the map
+ * @return map with the provided keys and values, excluding nulls
+ * @see kotlin.collections.mapOf(Pair[])
+ */
+public fun <K, V> mapOfNotNull(vararg mapping: Pair<K?, V?>): Map<K, V> {
+    return buildMap {
+        mapping.forEach { (k, v) ->
+            if (k != null && v != null) {
+                put(k, v)
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.SeparableConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
+import org.jetbrains.kotlinx.dl.api.core.util.mapOfNotNull
 
 internal object WeightMappings {
 
@@ -165,16 +166,6 @@ internal object WeightMappings {
             layer.gamma to layerBatchNormPaths.gammaPath,
             layer.beta to layerBatchNormPaths.betaPath
         )
-    }
-
-    private fun <K, V> mapOfNotNull(vararg mapping: Pair<K?, V?>): Map<K, V> {
-        return buildMap {
-            mapping.forEach { (k, v) ->
-                if (k != null && v != null) {
-                    put(k, v)
-                }
-            }
-        }
     }
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlinx.dl.api.inference.keras
 
+import org.jetbrains.kotlinx.dl.api.core.layer.KVariable
 import org.jetbrains.kotlinx.dl.api.core.layer.Layer
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.Conv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.ConvTranspose
@@ -12,8 +13,6 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.SeparableConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
-import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
-import org.jetbrains.kotlinx.dl.api.core.util.*
 
 internal object WeightMappings {
 
@@ -28,7 +27,7 @@ internal object WeightMappings {
     private const val DEPTHWISE_BIAS_DATA_PATH_TEMPLATE = "/%s/%s/depthwise_bias:0"
 
     // TODO: add loading for all layers with weights from Keras like Conv1D and Conv3D
-    internal fun getLayerVariables(layer: Layer): Map<String, Pair<String, LongArray>>? {
+    internal fun getLayerVariables(layer: Layer): Map<String, KVariable>? {
         return when (layer) {
             is Dense -> getDenseVariables(layer)
             is Conv2D -> getConv2DVariables(layer)
@@ -41,10 +40,10 @@ internal object WeightMappings {
     }
 
     internal fun getLayerVariableNames(layer: Layer): List<String>? {
-        return getLayerVariables(layer)?.map { (_, variable) -> variable.first }
+        return getLayerVariables(layer)?.values?.map(KVariable::name)
     }
 
-    internal fun getLayerVariablePathTemplates(layer: Layer, layerPaths: LayerPaths?): Map<String, String>? {
+    internal fun getLayerVariablePathTemplates(layer: Layer, layerPaths: LayerPaths?): Map<KVariable, String>? {
         return when (layer) {
             is Dense -> getDenseVariablesPathTemplates(layer, layerPaths)
             is Conv2D -> getConv2DVariablePathTemplates(layer, layerPaths)
@@ -56,99 +55,64 @@ internal object WeightMappings {
         }
     }
 
-    private fun getConv2DVariables(layer: Conv2D): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernel.shape.toLongArray()))
-        )
-        if (layer.useBias) {
-            variables["bias:0"] = Pair(convBiasVarName(layer.name, dim = 2), layer.bias!!.shape.toLongArray())
-        }
-        return variables
+    private fun getConv2DVariables(layer: Conv2D): Map<String, KVariable> {
+        return mapOfNotNull("kernel:0" to layer.kernel, "bias:0" to layer.bias)
     }
 
-    private fun getConv2DVariablePathTemplates(layer: Conv2D, layerPaths: LayerPaths?): Map<String, String> {
+    private fun getConv2DVariablePathTemplates(layer: Conv2D, layerPaths: LayerPaths?): Map<KVariable, String> {
         val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
             ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
-        val variables = mutableMapOf(
-            Pair(convKernelVarName(layer.name, dim = 2), layerConvOrDensePaths.kernelPath)
+        return mapOfNotNull(
+            layer.kernel to layerConvOrDensePaths.kernelPath,
+            layer.bias to layerConvOrDensePaths.biasPath
         )
-        if (layer.useBias) {
-            variables[convBiasVarName(layer.name, dim = 2)] = layerConvOrDensePaths.biasPath
-        }
-        return variables
     }
 
-    private fun getConvTransposeVariables(layer: ConvTranspose): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair("kernel:0", Pair(convTransposeKernelVarName(layer.name, layer.dimensions), layer.kernel.shape.toLongArray()))
-        )
-        if (layer.useBias) {
-            variables["bias:0"] = Pair(convTransposeBiasVarName(layer.name, layer.dimensions), layer.bias!!.shape.toLongArray())
-        }
-        return variables
+    private fun getConvTransposeVariables(layer: ConvTranspose): Map<String, KVariable> {
+        return mapOfNotNull("kernel:0" to layer.kernel, "bias:0" to layer.bias)
     }
 
-    private fun getConvTransposeVariablePathTemplates(layer: ConvTranspose, layerPaths: LayerPaths?): Map<String, String> {
+    private fun getConvTransposeVariablePathTemplates(layer: ConvTranspose,
+                                                      layerPaths: LayerPaths?
+    ): Map<KVariable, String> {
         val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
             ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
-        val variables = mutableMapOf(
-            Pair(convTransposeKernelVarName(layer.name, layer.dimensions), layerConvOrDensePaths.kernelPath)
+        return mapOfNotNull(
+            layer.kernel to layerConvOrDensePaths.kernelPath,
+            layer.bias to layerConvOrDensePaths.biasPath
         )
-        if (layer.useBias) {
-            variables[convTransposeBiasVarName(layer.name, layer.dimensions)] = layerConvOrDensePaths.biasPath
-        }
-        return variables
     }
 
-    private fun getDepthwiseConv2DVariables(layer: DepthwiseConv2D): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernel.shape.toLongArray()))
-        )
-        if (layer.useBias) {
-            variables["depthwise_bias:0"] = Pair(depthwiseConv2dBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
-        }
-        return variables
+    private fun getDepthwiseConv2DVariables(layer: DepthwiseConv2D): Map<String, KVariable> {
+        return mapOfNotNull("depthwise_kernel:0" to layer.kernel, "depthwise_bias:0" to layer.bias)
     }
 
     private fun getDepthwiseConv2DVariablePathTemplates(layer: DepthwiseConv2D,
                                                         layerPaths: LayerPaths?
-    ): Map<String, String> {
+    ): Map<KVariable, String> {
         val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
             ?: LayerConvOrDensePaths(
                 layer.name,
                 DEPTHWISE_KERNEL_DATA_PATH_TEMPLATE,
                 DEPTHWISE_BIAS_DATA_PATH_TEMPLATE
             )
-        val variables = mutableMapOf(
-            Pair(depthwiseConv2dKernelVarName(layer.name), layerConvOrDensePaths.kernelPath)
+        return mapOfNotNull(
+            layer.kernel to layerConvOrDensePaths.kernelPath,
+            layer.bias to layerConvOrDensePaths.biasPath
         )
-        if (layer.useBias) {
-            variables[depthwiseConv2dBiasVarName(layer.name)] = layerConvOrDensePaths.biasPath
-        }
-        return variables
     }
 
-    private fun getSeparableConv2DVariables(layer: SeparableConv2D): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair(
-                "depthwise_kernel:0",
-                Pair(separableConv2dDepthwiseKernelVarName(layer.name), layer.depthwiseKernel.shape.toLongArray())
-            ),
-            Pair(
-                "pointwise_kernel:0",
-                Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseKernel.shape.toLongArray())
-            )
+    private fun getSeparableConv2DVariables(layer: SeparableConv2D): Map<String, KVariable> {
+        return mapOfNotNull(
+            "depthwise_kernel:0" to layer.depthwiseKernel,
+            "pointwise_kernel:0" to layer.pointwiseKernel,
+            "bias:0" to layer.bias
         )
-        if (layer.useBias) {
-            variables["bias:0"] = Pair(separableConv2dBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
-        }
-        return variables
     }
 
-    private fun getSeparableConv2DVariablePathTemplates(
-        layer: SeparableConv2D,
-        layerPaths: LayerPaths?
-    ): Map<String, String> {
+    private fun getSeparableConv2DVariablePathTemplates(layer: SeparableConv2D,
+                                                        layerPaths: LayerPaths?
+    ): Map<KVariable, String> {
         val layerSeparableConv2DPaths = layerPaths as? LayerSeparableConv2DPaths
             ?: LayerSeparableConv2DPaths(
                 layer.name,
@@ -156,54 +120,37 @@ internal object WeightMappings {
                 POINTWISE_KERNEL_DATA_PATH_TEMPLATE,
                 DEPTHWISE_BIAS_DATA_PATH_TEMPLATE
             )
-        val variables = mutableMapOf(
-            Pair(separableConv2dDepthwiseKernelVarName(layer.name), layerSeparableConv2DPaths.depthwiseKernelPath),
-            Pair(separableConv2dPointwiseKernelVarName(layer.name), layerSeparableConv2DPaths.pointwiseKernelPath)
+        return mapOfNotNull(
+            layer.depthwiseKernel to layerSeparableConv2DPaths.depthwiseKernelPath,
+            layer.pointwiseKernel to layerSeparableConv2DPaths.pointwiseKernelPath,
+            layer.bias to layerSeparableConv2DPaths.biasPath
         )
-        if (layer.useBias) {
-            variables[separableConv2dBiasVarName(layer.name)] = layerSeparableConv2DPaths.biasPath
-        }
-        return variables
     }
 
-    private fun getDenseVariables(layer: Dense): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernel.shape.toLongArray()))
-        )
-        if (layer.useBias) {
-            variables["bias:0"] = Pair(denseBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
-        }
-        return variables
+    private fun getDenseVariables(layer: Dense): Map<String, KVariable> {
+        return mapOfNotNull("kernel:0" to layer.kernel, "bias:0" to layer.bias)
     }
 
-    private fun getDenseVariablesPathTemplates(layer: Dense, layerPaths: LayerPaths?): Map<String, String> {
+    private fun getDenseVariablesPathTemplates(layer: Dense, layerPaths: LayerPaths?): Map<KVariable, String> {
         val layerConvOrDensePaths = layerPaths as? LayerConvOrDensePaths
             ?: LayerConvOrDensePaths(layer.name, KERNEL_DATA_PATH_TEMPLATE, BIAS_DATA_PATH_TEMPLATE)
-        val variables = mutableMapOf(
-            Pair(denseKernelVarName(layer.name), layerConvOrDensePaths.kernelPath)
+        return mapOfNotNull(
+            layer.kernel to layerConvOrDensePaths.kernelPath,
+            layer.bias to layerConvOrDensePaths.biasPath
         )
-        if (layer.useBias) {
-            variables[denseBiasVarName(layer.name)] = layerConvOrDensePaths.biasPath
-        }
-        return variables
     }
 
-    private fun getBatchNormVariables(layer: BatchNorm): Map<String, Pair<String, LongArray>> {
-        val variables = mutableMapOf(
-            Pair("moving_mean:0", Pair(batchNormMovingMeanVarName(layer.name), layer.movingMean.shape.toLongArray())),
-            Pair("moving_variance:0", Pair(batchNormMovingVarianceVarName(layer.name), layer.movingVariance.shape.toLongArray()))
+    private fun getBatchNormVariables(layer: BatchNorm): Map<String, KVariable> {
+        return mapOfNotNull(
+            "moving_mean:0" to layer.movingMean,
+            "moving_variance:0" to layer.movingVariance,
+            "gamma:0" to layer.gamma,
+            "beta:0" to layer.beta
         )
-        if (layer.scale) {
-            variables["gamma:0"] = Pair(batchNormGammaVarName(layer.name), layer.gamma!!.shape.toLongArray())
-        }
-        if (layer.center) {
-            variables["beta:0"] = Pair(batchNormBetaVarName(layer.name), layer.beta!!.shape.toLongArray())
-        }
-        return variables
     }
 
 
-    private fun getBatchNormVariablePathTemplates(layer: BatchNorm, layerPaths: LayerPaths?): Map<String, String> {
+    private fun getBatchNormVariablePathTemplates(layer: BatchNorm, layerPaths: LayerPaths?): Map<KVariable, String> {
         val layerBatchNormPaths = layerPaths as? LayerBatchNormPaths
             ?: LayerBatchNormPaths(
                 layer.name,
@@ -212,17 +159,22 @@ internal object WeightMappings {
                 MOVING_MEAN_DATA_PATH_TEMPLATE,
                 MOVING_VARIANCE_DATA_PATH_TEMPLATE
             )
-        val variables = mutableMapOf(
-            Pair(batchNormMovingMeanVarName(layer.name), layerBatchNormPaths.movingMeanPath),
-            Pair(batchNormMovingVarianceVarName(layer.name), layerBatchNormPaths.movingVariancePath)
+        return mapOfNotNull(
+            layer.movingMean to layerBatchNormPaths.movingMeanPath,
+            layer.movingVariance to layerBatchNormPaths.movingVariancePath,
+            layer.gamma to layerBatchNormPaths.gammaPath,
+            layer.beta to layerBatchNormPaths.betaPath
         )
-        if (layer.scale) {
-            variables[batchNormGammaVarName(layer.name)] = layerBatchNormPaths.gammaPath
+    }
+
+    private fun <K, V> mapOfNotNull(vararg mapping: Pair<K?, V?>): Map<K, V> {
+        return buildMap {
+            mapping.forEach { (k, v) ->
+                if (k != null && v != null) {
+                    put(k, v)
+                }
+            }
         }
-        if (layer.center) {
-            variables[batchNormBetaVarName(layer.name)] = layerBatchNormPaths.betaPath
-        }
-        return variables
     }
 }
 

--- a/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
+++ b/api/src/main/kotlin/org/jetbrains/kotlinx/dl/api/inference/keras/WeightMappings.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.DepthwiseConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.convolutional.SeparableConv2D
 import org.jetbrains.kotlinx.dl.api.core.layer.core.Dense
 import org.jetbrains.kotlinx.dl.api.core.layer.normalization.BatchNorm
+import org.jetbrains.kotlinx.dl.api.core.shape.toLongArray
 import org.jetbrains.kotlinx.dl.api.core.util.*
 
 internal object WeightMappings {
@@ -57,10 +58,10 @@ internal object WeightMappings {
 
     private fun getConv2DVariables(layer: Conv2D): Map<String, Pair<String, LongArray>> {
         val variables = mutableMapOf(
-            Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernelShapeArray!!))
+            Pair("kernel:0", Pair(convKernelVarName(layer.name, dim = 2), layer.kernel.shape.toLongArray()))
         )
         if (layer.useBias) {
-            variables["bias:0"] = Pair(convBiasVarName(layer.name, dim = 2), layer.biasShapeArray!!)
+            variables["bias:0"] = Pair(convBiasVarName(layer.name, dim = 2), layer.bias!!.shape.toLongArray())
         }
         return variables
     }
@@ -79,10 +80,10 @@ internal object WeightMappings {
 
     private fun getConvTransposeVariables(layer: ConvTranspose): Map<String, Pair<String, LongArray>> {
         val variables = mutableMapOf(
-            Pair("kernel:0", Pair(convTransposeKernelVarName(layer.name, layer.dimensions), layer.kernelShapeArray!!))
+            Pair("kernel:0", Pair(convTransposeKernelVarName(layer.name, layer.dimensions), layer.kernel.shape.toLongArray()))
         )
         if (layer.useBias) {
-            variables["bias:0"] = Pair(convTransposeBiasVarName(layer.name, layer.dimensions), layer.biasShapeArray!!)
+            variables["bias:0"] = Pair(convTransposeBiasVarName(layer.name, layer.dimensions), layer.bias!!.shape.toLongArray())
         }
         return variables
     }
@@ -101,10 +102,10 @@ internal object WeightMappings {
 
     private fun getDepthwiseConv2DVariables(layer: DepthwiseConv2D): Map<String, Pair<String, LongArray>> {
         val variables = mutableMapOf(
-            Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernelShapeArray!!))
+            Pair("depthwise_kernel:0", Pair(depthwiseConv2dKernelVarName(layer.name), layer.kernel.shape.toLongArray()))
         )
         if (layer.useBias) {
-            variables["depthwise_bias:0"] = Pair(depthwiseConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+            variables["depthwise_bias:0"] = Pair(depthwiseConv2dBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
         }
         return variables
     }
@@ -131,15 +132,15 @@ internal object WeightMappings {
         val variables = mutableMapOf(
             Pair(
                 "depthwise_kernel:0",
-                Pair(separableConv2dDepthwiseKernelVarName(layer.name), layer.depthwiseShapeArray!!)
+                Pair(separableConv2dDepthwiseKernelVarName(layer.name), layer.depthwiseKernel.shape.toLongArray())
             ),
             Pair(
                 "pointwise_kernel:0",
-                Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseShapeArray!!)
+                Pair(separableConv2dPointwiseKernelVarName(layer.name), layer.pointwiseKernel.shape.toLongArray())
             )
         )
         if (layer.useBias) {
-            variables["bias:0"] = Pair(separableConv2dBiasVarName(layer.name), layer.biasShapeArray!!)
+            variables["bias:0"] = Pair(separableConv2dBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
         }
         return variables
     }
@@ -167,10 +168,10 @@ internal object WeightMappings {
 
     private fun getDenseVariables(layer: Dense): Map<String, Pair<String, LongArray>> {
         val variables = mutableMapOf(
-            Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernelShapeArray!!))
+            Pair("kernel:0", Pair(denseKernelVarName(layer.name), layer.kernel.shape.toLongArray()))
         )
         if (layer.useBias) {
-            variables["bias:0"] = Pair(denseBiasVarName(layer.name), layer.biasShapeArray!!)
+            variables["bias:0"] = Pair(denseBiasVarName(layer.name), layer.bias!!.shape.toLongArray())
         }
         return variables
     }
@@ -189,14 +190,14 @@ internal object WeightMappings {
 
     private fun getBatchNormVariables(layer: BatchNorm): Map<String, Pair<String, LongArray>> {
         val variables = mutableMapOf(
-            Pair("moving_mean:0", Pair(batchNormMovingMeanVarName(layer.name), layer.movingMeanShapeArray!!)),
-            Pair("moving_variance:0", Pair(batchNormMovingVarianceVarName(layer.name), layer.movingVarianceShapeArray!!))
+            Pair("moving_mean:0", Pair(batchNormMovingMeanVarName(layer.name), layer.movingMean.shape.toLongArray())),
+            Pair("moving_variance:0", Pair(batchNormMovingVarianceVarName(layer.name), layer.movingVariance.shape.toLongArray()))
         )
         if (layer.scale) {
-            variables["gamma:0"] = Pair(batchNormGammaVarName(layer.name), layer.gammaShapeArray!!)
+            variables["gamma:0"] = Pair(batchNormGammaVarName(layer.name), layer.gamma!!.shape.toLongArray())
         }
         if (layer.center) {
-            variables["beta:0"] = Pair(batchNormBetaVarName(layer.name), layer.betaShapeArray!!)
+            variables["beta:0"] = Pair(batchNormBetaVarName(layer.name), layer.beta!!.shape.toLongArray())
         }
         return variables
     }


### PR DESCRIPTION
This PR refactors loading model weight, to use `KVariable` in the code. This will allow later to deal with #4 by taking the initialiser from the `KVariable` instance instead of trying to find it by name.